### PR TITLE
rlottie: remove dependancy of -stdc++14 flag to link against rlottie library

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -22,9 +22,8 @@ add_library(rlottie::rlottie ALIAS rlottie)
 #declare target compilation options
 target_compile_options(rlottie
                     PUBLIC
-                        -std=c++14
                     PRIVATE
-                        -Wall -fvisibility=hidden -O2)
+                        -Wall -fvisibility=hidden -O2 -std=c++14)
 
 #declare dependancy
 set( CMAKE_THREAD_PREFER_PTHREAD TRUE )

--- a/rlottie.pc.in
+++ b/rlottie.pc.in
@@ -3,4 +3,4 @@ Description: A rlottie library
 Version: @player_version@
 Requires:
 Libs: -L@LIBDIR@ -lrlottie
-Cflags: -I@INCDIR@ -std=c++14
+Cflags: -I@INCDIR@


### PR DESCRIPTION
make -stdc++14 dependency private so that its not a requirement to link against rlottie library