### PR TITLE
[rlottie]: clear any existing brush data before drawing bitmap.

### DIFF
--- a/src/vector/vpainter.cpp
+++ b/src/vector/vpainter.cpp
@@ -168,6 +168,9 @@ void  VPainter::drawBitmap(const VRect &target, const VBitmap &bitmap, const VRe
 {
     if (!bitmap.valid()) return;
 
+    // clear any existing brush data.
+    setBrush(VBrush());
+
     if (target.size() == source.size()) {
         mImpl->drawBitmapUntransform(target, bitmap, source);
     } else {


### PR DESCRIPTION
#9 