### PR TITLE
Win support

### DIFF
--- a/src/lottie/lottieitem.cpp
+++ b/src/lottie/lottieitem.cpp
@@ -19,6 +19,7 @@
 #include "lottieitem.h"
 #include <cmath>
 #include <algorithm>
+#include <iterator> 
 #include "vbitmap.h"
 #include "vdasher.h"
 #include "vpainter.h"

--- a/src/lottie/lottiemodel.cpp
+++ b/src/lottie/lottiemodel.cpp
@@ -21,6 +21,7 @@
 #include "vimageloader.h"
 #include <cassert>
 #include <stack>
+#include <iterator>  
 
 /*
  * We process the iterator objects in the children list

--- a/src/lottie/lottiemodel.h
+++ b/src/lottie/lottiemodel.h
@@ -22,6 +22,7 @@
 #include<vector>
 #include<memory>
 #include<unordered_map>
+#include <algorithm>
 #include"vpoint.h"
 #include"vrect.h"
 #include"vinterpolator.h"
@@ -760,11 +761,22 @@ public:
         float offset = fmod(mOffset.value(frameNo), 360.0f)/ 360.0f;
 
         float diff = fabs(start - end);
-        if (vCompare(diff, 0)) return {0, 0};
-        if (vCompare(diff, 1)) return {0, 1};
+		if (vCompare(diff, 0.0f)) {
+			Segment tmp;
+			tmp.start = 0;
+			tmp.end = 0;
+			return tmp;
+		} 
+
+		if (vCompare(diff, 1.0f)) {
+			Segment tmp;
+			tmp.start = 0;
+			tmp.end = 1;
+			return tmp;
+		}
 
         // no offset case
-        if (vCompare(fabs(offset), 0.0)) {
+        if (vCompare(fabs(offset), 0.0f)) {
             return noloop(start, end);
         } else {
             if (offset > 0) {

--- a/src/vector/freetype/v_ft_math.cpp
+++ b/src/vector/freetype/v_ft_math.cpp
@@ -18,7 +18,38 @@
 #include "v_ft_math.h"
 #include <math.h>
 
-#define SW_FT_MSB(x) (31 - __builtin_clz(x))
+//form https://github.com/chromium/chromium/blob/59afd8336009c9d97c22854c52e0382b62b3aa5e/third_party/abseil-cpp/absl/base/internal/bits.h
+
+#if defined(_MSC_VER)
+#include <intrin.h>
+static unsigned int __inline clz(unsigned int x) {
+	unsigned long r = 0;
+	if (x != 0)
+	{
+		_BitScanReverse(&r, x);
+	}
+	return  r;
+}
+#define SW_FT_MSB(x)  (clz(x))
+#elif defined(__GNUC__)
+#define SW_FT_MSB(x)  (31 - __builtin_clz(x))
+#else
+static unsigned int __inline clz(unsigned int x) {
+	int c = 31;
+	x &= ~x + 1;
+	if (n & 0x0000FFFF) c -= 16;
+	if (n & 0x00FF00FF) c -= 8;
+	if (n & 0x0F0F0F0F) c -= 4;
+	if (n & 0x33333333) c -= 2;
+	if (n & 0x55555555) c -= 1;
+	return c;
+}
+#define SW_FT_MSB(x)  (clz(x))
+#endif
+
+
+
+
 
 #define SW_FT_PAD_FLOOR(x, n) ((x) & ~((n)-1))
 #define SW_FT_PAD_ROUND(x, n) SW_FT_PAD_FLOOR((x) + ((n) / 2), n)

--- a/src/vector/vglobal.h
+++ b/src/vector/vglobal.h
@@ -43,8 +43,21 @@ typedef uint8_t  uchar;
 
 #endif
 
-#define V_UNUSED __attribute__((__unused__))
-#define V_REQUIRED_RESULT __attribute__((__warn_unused_result__))
+#ifndef __has_attribute
+# define __has_attribute(x) 0
+#endif /* !__has_attribute */
+
+#if __has_attribute(unused)
+# define V_UNUSED __attribute__((__unused__))
+#else
+# define V_UNUSED
+#endif /* V_UNUSED */
+
+#if __has_attribute(warn_unused_result)
+# define V_REQUIRED_RESULT __attribute__((__warn_unused_result__))
+#else
+# define V_REQUIRED_RESULT
+#endif /* V_REQUIRED_RESULT */
 
 #define V_CONSTEXPR constexpr
 #define V_NOTHROW noexcept

--- a/src/vector/vpainter.cpp
+++ b/src/vector/vpainter.cpp
@@ -18,6 +18,7 @@
 
 #include "vpainter.h"
 #include "vdrawhelper.h"
+#include <algorithm>
 
 V_BEGIN_NAMESPACE
 

--- a/src/vector/vpath.cpp
+++ b/src/vector/vpath.cpp
@@ -19,6 +19,7 @@
 #include "vpath.h"
 #include <cassert>
 #include <vector>
+#include <iterator> 
 #include "vbezier.h"
 #include "vdebug.h"
 #include "vrect.h"

--- a/src/vector/vrect.cpp
+++ b/src/vector/vrect.cpp
@@ -17,6 +17,7 @@
  */
 
 #include "vrect.h"
+#include <algorithm>
 
 VRect VRect::operator&(const VRect &r) const
 {


### PR DESCRIPTION
1、__builtin_clz support
2、 V_UNUSED  and V_REQUIRED  support
3、dlopen dlclose support
4、some c++/c header no found  solve
5、vCompare has two define ,one of arg is double type,and one is float type.  If your write `vCompare(mDashOffset, 0)` may be errror on same compiler（such as msvc）。so I change same of this code  to `vCompare(mDashOffset, 0.0f)`

Introduce an interesting resource to your:
https://skottie.skia.org

at last sorry for my english。If you know Chinese, let's communicate in Chinese。



