### PR TITLE
rlottie: Fix issue with intersect mask

### DIFF
--- a/src/lottie/lottieitem.cpp
+++ b/src/lottie/lottieitem.cpp
@@ -343,6 +343,8 @@ VRle LOTLayerMaskItem::maskRle(const VRect &clipRect)
             break;
         }
         case LOTMaskData::Mode::Intersect: {
+            if (rle.empty() && !clipRect.empty())
+                rle = VRle::toRle(clipRect);
             rle = rle & i.rle();
             break;
         }


### PR DESCRIPTION
When do an Intersect mask, it need to initialize rle like a Subtract.