### PR TITLE
rlottie: mask item shouldn't inherit parent opacity

### DIFF
--- a/src/lottie/lottieitem.cpp
+++ b/src/lottie/lottieitem.cpp
@@ -193,7 +193,7 @@ bool LOTCompItem::render(const rlottie::Surface &surface)
 }
 
 void LOTMaskItem::update(int frameNo, const VMatrix &parentMatrix,
-                         float parentAlpha, const DirtyFlag &flag)
+                         float /*parentAlpha*/, const DirtyFlag &flag)
 {
     if (flag.testFlag(DirtyFlagBit::None) && mData->isStatic()) return;
 
@@ -204,9 +204,8 @@ void LOTMaskItem::update(int frameNo, const VMatrix &parentMatrix,
     } else {
         mData->mShape.value(frameNo).toPath(mLocalPath);
     }
-    float opacity = mData->opacity(frameNo);
-    opacity = opacity * parentAlpha;
-    mCombinedAlpha = opacity;
+    /* mask item dosen't inherit opacity */
+    mCombinedAlpha = mData->opacity(frameNo);
 
     mFinalPath.clone(mLocalPath);
     mFinalPath.transform(parentMatrix);


### PR DESCRIPTION
Mask item in AE has its own maskOpacity property. As mask items are local to layer and it affects all the visualization of that particular layer , inherited opacity should only affect the content of the layer not the mask of the layer.