### PR TITLE
rlottie: always propagate update for precomp layer.

### DIFF
--- a/src/lottie/lottieitem.cpp
+++ b/src/lottie/lottieitem.cpp
@@ -495,7 +495,9 @@ void LOTLayerItem::update(int frameNumber, const VMatrix &parentMatrix,
     }
 
     // 5. if no parent property change and layer is static then nothing to do.
-    if (flag().testFlag(DirtyFlagBit::None) && isStatic()) return;
+    if (!mLayerData->precompLayer() &&
+        flag().testFlag(DirtyFlagBit::None) &&
+        isStatic()) return;
 
     // 6. update the content of the layer
     updateContent();

--- a/src/lottie/lottiemodel.h
+++ b/src/lottie/lottiemodel.h
@@ -378,6 +378,7 @@ public:
     bool autoOrient() const noexcept{return mAutoOrient;}
     int timeRemap(int frameNo) const;
     VSize layerSize() const {return mLayerSize;}
+    bool precompLayer() const {return mLayerType == LayerType::Precomp;}
 public:
     struct SolidLayer {
         int            mWidth{0};


### PR DESCRIPTION
Precomp layers can be static with more than 1 frame inside it.
so always propagate update to all its child layers.