### PR TITLE
rlottie/parser: Fix float data parsing when data in array form.

### DIFF
--- a/src/lottie/lottieparser.cpp
+++ b/src/lottie/lottieparser.cpp
@@ -1685,8 +1685,10 @@ void LottieParserImpl::getValue(float &val)
 {
     if (PeekType() == kArrayType) {
         EnterArray();
+        if (NextArrayValue()) val = GetDouble();
+        //discard rest
         while (NextArrayValue()) {
-            val = GetDouble();
+            GetDouble();
         }
     } else if (PeekType() == kNumberType) {
         val = GetDouble();


### PR DESCRIPTION
Take only the 1st element and discard the rest.