### PR TITLE
rlottie: make sure rle object shared between 2 threads always keeps r…

### DIFF
--- a/src/lottie/lottieitem.cpp
+++ b/src/lottie/lottieitem.cpp
@@ -214,7 +214,9 @@ void LOTMaskItem::update(int frameNo, const VMatrix &parentMatrix,
 
     if (!mRleFuture) mRleFuture = std::make_shared<VSharedState<VRle>>();
 
+    if (mRleFuture->valid()) mRle = mRleFuture->get();
     mRleFuture->reuse();
+
     VRaster::generateFillInfo(mRleFuture, std::move(tmp), std::move(mRle));
     mRle = VRle();
 }
@@ -402,7 +404,11 @@ VRle LOTLayerMaskItem::maskRle(const VRect &clipRect)
         }
     }
 
-    mRle = rle;
+    if (!rle.empty() && !rle.unique()) {
+        mRle.clone(rle);
+    } else {
+        mRle = rle;
+    }
     mDirty = false;
     return mRle;
 }
@@ -702,7 +708,9 @@ void LOTClipperItem::update(const VMatrix &matrix)
 
     if (!mRleFuture) mRleFuture = std::make_shared<VSharedState<VRle>>();
 
+    if (mRleFuture->valid()) mRle = mRleFuture->get();
     mRleFuture->reuse();
+
     VRaster::generateFillInfo(mRleFuture, std::move(tmp), std::move(mRle));
     mRle = VRle();
 }

--- a/src/vector/vdrawable.cpp
+++ b/src/vector/vdrawable.cpp
@@ -26,6 +26,7 @@ void VDrawable::preprocess(const VRect &clip)
 
         if (!mRleFuture) mRleFuture = std::make_shared<VSharedState<VRle>>();
 
+        if (mRleFuture->valid()) mRle = mRleFuture->get();
         mRleFuture->reuse();
 
         if (mStroke.enable) {

--- a/src/vector/vraster.h
+++ b/src/vector/vraster.h
@@ -56,7 +56,7 @@ private:
     std::mutex               _mutex;
     std::condition_variable  _cv;
     bool                     _ready{false};
-    bool                     _valid{true};
+    bool                     _valid{false};
 };
 
 using RleShare = std::shared_ptr<VSharedState<VRle>>;


### PR DESCRIPTION
…efcount 1 to avoid copy