### PR TITLE
lottieitem: Add image property in LOTNode

### DIFF
--- a/inc/rlottiecommon.h
+++ b/inc/rlottiecommon.h
@@ -181,6 +181,17 @@ typedef struct LOTNode {
         float fradius;
     } mGradient;
 
+    struct {
+        unsigned char* data;
+        int width;
+        int height;
+        struct {
+           float m11; float m12; float m13;
+           float m21; float m22; float m23;
+           float m31; float m32; float m33;
+        } mMatrix;
+    } mImageInfo;
+
     int       mFlag;
     LOTBrushType mBrushType;
     LOTFillRule  mFillRule;

--- a/src/lottie/lottieitem.cpp
+++ b/src/lottie/lottieitem.cpp
@@ -852,9 +852,17 @@ void LOTImageLayerItem::buildLayerNode()
         lotDrawable->mCNode->mImageInfo.width = mRenderNode->mBrush.mTexture.width();
         lotDrawable->mCNode->mImageInfo.height = mRenderNode->mBrush.mTexture.height();
 
-        combinedMatrix().getMatrix(&lotDrawable->mCNode->mImageInfo.mMatrix.m11, &lotDrawable->mCNode->mImageInfo.mMatrix.m12, &lotDrawable->mCNode->mImageInfo.mMatrix.m13,
-                                   &lotDrawable->mCNode->mImageInfo.mMatrix.m21, &lotDrawable->mCNode->mImageInfo.mMatrix.m22, &lotDrawable->mCNode->mImageInfo.mMatrix.m23,
-                                   &lotDrawable->mCNode->mImageInfo.mMatrix.m31, &lotDrawable->mCNode->mImageInfo.mMatrix.m32, &lotDrawable->mCNode->mImageInfo.mMatrix.m33);
+        lotDrawable->mCNode->mImageInfo.mMatrix.m11 = combinedMatrix().m_11();
+        lotDrawable->mCNode->mImageInfo.mMatrix.m12 = combinedMatrix().m_12();
+        lotDrawable->mCNode->mImageInfo.mMatrix.m13 = combinedMatrix().m_13();
+
+        lotDrawable->mCNode->mImageInfo.mMatrix.m21 = combinedMatrix().m_21();
+        lotDrawable->mCNode->mImageInfo.mMatrix.m22 = combinedMatrix().m_22();
+        lotDrawable->mCNode->mImageInfo.mMatrix.m23 = combinedMatrix().m_23();
+
+        lotDrawable->mCNode->mImageInfo.mMatrix.m31 = combinedMatrix().m_tx();
+        lotDrawable->mCNode->mImageInfo.mMatrix.m32 = combinedMatrix().m_ty();
+        lotDrawable->mCNode->mImageInfo.mMatrix.m33 = combinedMatrix().m_13();
 
         mCNodeList.push_back(lotDrawable->mCNode.get());
     }

--- a/src/lottie/lottieitem.cpp
+++ b/src/lottie/lottieitem.cpp
@@ -847,6 +847,15 @@ void LOTImageLayerItem::buildLayerNode()
     for (auto &i : mDrawableList) {
         LOTDrawable *lotDrawable = static_cast<LOTDrawable *>(i);
         lotDrawable->sync();
+
+        lotDrawable->mCNode->mImageInfo.data = mRenderNode->mBrush.mTexture.data();
+        lotDrawable->mCNode->mImageInfo.width = mRenderNode->mBrush.mTexture.width();
+        lotDrawable->mCNode->mImageInfo.height = mRenderNode->mBrush.mTexture.height();
+
+        combinedMatrix().getMatrix(&lotDrawable->mCNode->mImageInfo.mMatrix.m11, &lotDrawable->mCNode->mImageInfo.mMatrix.m12, &lotDrawable->mCNode->mImageInfo.mMatrix.m13,
+                                   &lotDrawable->mCNode->mImageInfo.mMatrix.m21, &lotDrawable->mCNode->mImageInfo.mMatrix.m22, &lotDrawable->mCNode->mImageInfo.mMatrix.m23,
+                                   &lotDrawable->mCNode->mImageInfo.mMatrix.m31, &lotDrawable->mCNode->mImageInfo.mMatrix.m32, &lotDrawable->mCNode->mImageInfo.mMatrix.m33);
+
         mCNodeList.push_back(lotDrawable->mCNode.get());
     }
     layerNode()->mNodeList.ptr = mCNodeList.data();

--- a/src/vector/vmatrix.cpp
+++ b/src/vector/vmatrix.cpp
@@ -64,23 +64,6 @@ bool VMatrix::isTranslating() const
     return type() >= MatrixType::Translate;
 }
 
-void VMatrix::getMatrix(float *_m11, float *_m12, float *_m13,
-                        float *_m21, float *_m22, float *_m23,
-                        float *_m31, float *_m32, float *_m33)
-{
-   if (_m11)  *_m11 = m11;
-   if (_m12)  *_m12 = m12;
-   if (_m13)  *_m13 = m13;
-
-   if (_m21)  *_m21 = m21;
-   if (_m22)  *_m22 = m22;
-   if (_m23)  *_m23 = m23;
-
-   if (_m31)  *_m31 = mtx;
-   if (_m32)  *_m32 = mty;
-   if (_m33)  *_m33 = m33;
-}
-
 VMatrix &VMatrix::operator*=(float num)
 {
     if (num == 1.) return *this;

--- a/src/vector/vmatrix.cpp
+++ b/src/vector/vmatrix.cpp
@@ -64,6 +64,23 @@ bool VMatrix::isTranslating() const
     return type() >= MatrixType::Translate;
 }
 
+void VMatrix::getMatrix(float *_m11, float *_m12, float *_m13,
+                        float *_m21, float *_m22, float *_m23,
+                        float *_m31, float *_m32, float *_m33)
+{
+   if (_m11)  *_m11 = m11;
+   if (_m12)  *_m12 = m12;
+   if (_m13)  *_m13 = m13;
+
+   if (_m21)  *_m21 = m21;
+   if (_m22)  *_m22 = m22;
+   if (_m23)  *_m23 = m23;
+
+   if (_m31)  *_m31 = mtx;
+   if (_m32)  *_m32 = mty;
+   if (_m33)  *_m33 = m33;
+}
+
 VMatrix &VMatrix::operator*=(float num)
 {
     if (num == 1.) return *this;

--- a/src/vector/vmatrix.h
+++ b/src/vector/vmatrix.h
@@ -46,6 +46,10 @@ public:
     MatrixType   type() const;
     inline float determinant() const;
 
+    void         getMatrix(float *_m11, float *_m12, float *_m13,
+                           float *_m21, float *_m22, float *_m23,
+                           float *_m31, float *_m32, float *_m33);
+
     VMatrix &translate(VPointF pos) { return translate(pos.x(), pos.y()); };
     VMatrix &translate(float dx, float dy);
     VMatrix &scale(VPointF s) { return scale(s.x(), s.y()); };

--- a/src/vector/vmatrix.h
+++ b/src/vector/vmatrix.h
@@ -46,9 +46,17 @@ public:
     MatrixType   type() const;
     inline float determinant() const;
 
-    void         getMatrix(float *_m11, float *_m12, float *_m13,
-                           float *_m21, float *_m22, float *_m23,
-                           float *_m31, float *_m32, float *_m33);
+    float        m_11() const { return m11;}
+    float        m_12() const { return m12;}
+    float        m_13() const { return m13;}
+
+    float        m_21() const { return m21;}
+    float        m_22() const { return m22;}
+    float        m_23() const { return m23;}
+
+    float        m_tx() const { return mtx;}
+    float        m_ty() const { return mty;}
+    float        m_33() const { return m33;}
 
     VMatrix &translate(VPointF pos) { return translate(pos.x(), pos.y()); };
     VMatrix &translate(float dx, float dy);


### PR DESCRIPTION
The image properties are image data, size, and matrix information.
If the lottie item is an image item, the image property is stored in the Nodelist.