### PR TITLE
lottieitem: Add image property in LOTNode

### DIFF
--- a/inc/rlottiecommon.h
+++ b/inc/rlottiecommon.h
@@ -181,6 +181,17 @@ typedef struct LOTNode {
         float fradius;
     } mGradient;
 
+    struct {
+        unsigned char* data;
+        int width;
+        int height;
+        struct {
+           float m11; float m12; float m13;
+           float m21; float m22; float m23;
+           float m31; float m32; float m33;
+        } mMatrix;
+    } mImageInfo;
+
     int       mFlag;
     LOTBrushType mBrushType;
     LOTFillRule  mFillRule;

--- a/src/lottie/lottieitem.cpp
+++ b/src/lottie/lottieitem.cpp
@@ -847,6 +847,23 @@ void LOTImageLayerItem::buildLayerNode()
     for (auto &i : mDrawableList) {
         LOTDrawable *lotDrawable = static_cast<LOTDrawable *>(i);
         lotDrawable->sync();
+
+        lotDrawable->mCNode->mImageInfo.data = mRenderNode->mBrush.mTexture.data();
+        lotDrawable->mCNode->mImageInfo.width = mRenderNode->mBrush.mTexture.width();
+        lotDrawable->mCNode->mImageInfo.height = mRenderNode->mBrush.mTexture.height();
+
+        lotDrawable->mCNode->mImageInfo.mMatrix.m11 = combinedMatrix().m_11();
+        lotDrawable->mCNode->mImageInfo.mMatrix.m12 = combinedMatrix().m_12();
+        lotDrawable->mCNode->mImageInfo.mMatrix.m13 = combinedMatrix().m_13();
+
+        lotDrawable->mCNode->mImageInfo.mMatrix.m21 = combinedMatrix().m_21();
+        lotDrawable->mCNode->mImageInfo.mMatrix.m22 = combinedMatrix().m_22();
+        lotDrawable->mCNode->mImageInfo.mMatrix.m23 = combinedMatrix().m_23();
+
+        lotDrawable->mCNode->mImageInfo.mMatrix.m31 = combinedMatrix().m_tx();
+        lotDrawable->mCNode->mImageInfo.mMatrix.m32 = combinedMatrix().m_ty();
+        lotDrawable->mCNode->mImageInfo.mMatrix.m33 = combinedMatrix().m_13();
+
         mCNodeList.push_back(lotDrawable->mCNode.get());
     }
     layerNode()->mNodeList.ptr = mCNodeList.data();

--- a/src/vector/vmatrix.h
+++ b/src/vector/vmatrix.h
@@ -46,6 +46,18 @@ public:
     MatrixType   type() const;
     inline float determinant() const;
 
+    float        m_11() const { return m11;}
+    float        m_12() const { return m12;}
+    float        m_13() const { return m13;}
+
+    float        m_21() const { return m21;}
+    float        m_22() const { return m22;}
+    float        m_23() const { return m23;}
+
+    float        m_tx() const { return mtx;}
+    float        m_ty() const { return mty;}
+    float        m_33() const { return m33;}
+
     VMatrix &translate(VPointF pos) { return translate(pos.x(), pos.y()); };
     VMatrix &translate(float dx, float dy);
     VMatrix &scale(VPointF s) { return scale(s.x(), s.y()); };


### PR DESCRIPTION
The image properties are image data, size, and matrix information.
If the lottie item is an image item, the image property is stored in the Nodelist.