### PR TITLE
rlottie/parser: refactor image asset parsing.

### DIFF
--- a/src/lottie/lottieitem.cpp
+++ b/src/lottie/lottieitem.cpp
@@ -779,9 +779,6 @@ void LOTImageLayerItem::updateContent()
         mRenderNode = std::make_unique<LOTDrawable>();
         mRenderNode->mType = VDrawable::Type::Fill;
         mRenderNode->mFlag |= VDrawable::DirtyState::All;
-        // load image
-        //@TODO find a better way to load
-        // so that can be shared by multiple layers
         VBrush brush(mLayerData->mAsset->bitmap());
         mRenderNode->setBrush(brush);
     }

--- a/src/lottie/lottiemodel.cpp
+++ b/src/lottie/lottiemodel.cpp
@@ -323,14 +323,12 @@ void LOTGradient::update(std::unique_ptr<VGradient> &grad, int frameNo)
     }
 }
 
-VBitmap
-LOTAsset::bitmap() const
+void LOTAsset::loadImageData(std::string data)
 {
-    if (!mImageData.empty()) {
-        return VImageLoader::instance().load(mImageData.c_str(), mImageData.length());
-    } else if (!mImagePath.empty()) {
-        return VImageLoader::instance().load(mImagePath.c_str());
-    } else {
-        return VBitmap();
-    }
+    if (!data.empty()) mBitmap = VImageLoader::instance().load(data.c_str(), data.length());
+}
+
+void LOTAsset::loadImagePath(std::string path)
+{
+    if (!path.empty()) mBitmap = VImageLoader::instance().load(path.c_str());
 }

--- a/src/lottie/lottiemodel.h
+++ b/src/lottie/lottiemodel.h
@@ -398,7 +398,9 @@ struct LOTAsset
     };
     bool isStatic() const {return mStatic;}
     void setStatic(bool value) {mStatic = value;}
-    VBitmap  bitmap() const;
+    VBitmap  bitmap() const {return mBitmap;}
+    void loadImageData(std::string data);
+    void loadImagePath(std::string Path);
     Type                                      mAssetType{Type::Precomp};
     bool                                      mStatic{true};
     std::string                               mRefId; // ref id
@@ -406,8 +408,7 @@ struct LOTAsset
     // image asset data
     int                                       mWidth{0};
     int                                       mHeight{0};
-    std::string                               mImagePath;
-    std::string                               mImageData;
+    VBitmap                                   mBitmap;
 };
 
 struct LOT3DData

--- a/src/lottie/lottieparser.cpp
+++ b/src/lottie/lottieparser.cpp
@@ -712,14 +712,17 @@ std::shared_ptr<LOTAsset> LottieParserImpl::parseAsset()
         }
     }
 
-    if (embededResource) {
-        // embeder resource should start with "data:"
-        if (filename.find("data:", 0) == 0) {
-            asset->mImageData = convertFromBase64(filename);
+    if (asset->mAssetType == LOTAsset::Type::Image) {
+        if (embededResource) {
+            // embeder resource should start with "data:"
+            if (filename.find("data:", 0) == 0) {
+                asset->loadImageData(convertFromBase64(filename));
+            }
+        } else {
+            asset->loadImagePath(mDirPath + relativePath + filename);
         }
-    } else {
-        asset->mImagePath = mDirPath + relativePath + filename;
     }
+
     return sharedAsset;
 }
 


### PR DESCRIPTION
- generate bitmap while parsing the image asset and store it there.
- remove storing the imagedata in the asset.
- share the bitmap across multiple layers who wants to use the image.