### PR TITLE
rlottie: Fix precomp layer rendering issue when it has alpha value

### DIFF
--- a/src/lottie/lottieitem.h
+++ b/src/lottie/lottieitem.h
@@ -95,6 +95,8 @@ public:
    int id() const {return mLayerData->id();}
    int parentId() const {return mLayerData->parentId();}
    void setParentLayer(LOTLayerItem *parent){mParentLayer = parent;}
+   void setComplexContent(bool value) { mComplexContent = value;}
+   bool complexContent() const {return mComplexContent;}
    virtual void update(int frameNo, const VMatrix &parentMatrix, float parentAlpha);
    VMatrix matrix(int frameNo) const;
    virtual void renderList(std::vector<VDrawable *> &){}
@@ -125,6 +127,7 @@ protected:
    float                                       mCombinedAlpha{0.0};
    int                                         mFrameNo{-1};
    DirtyFlag                                   mDirtyFlag{DirtyFlagBit::All};
+   bool                                        mComplexContent{false};
 };
 
 class LOTCompLayerItem: public LOTLayerItem
@@ -138,6 +141,7 @@ public:
 protected:
    void updateContent() final;
 private:
+    void renderHelper(VPainter *painter, const VRle &mask, const VRle &matteRle);
     void renderMatteLayer(VPainter *painter, const VRle &inheritMask, const VRle &matteRle,
                           LOTLayerItem *layer, LOTLayerItem *src);
 private:


### PR DESCRIPTION
When the precomp layer has alpha transparency and has more than 1 child layer and they overlap each other
if we just propagate the alpha to child layer it will be applied twice in overlapped area.
in this case we treat the precomp layer as complex content and don't propagate the alpha transparency.
instead we create a buffer and draw all the child layers and then we blend with the main buffer
with the alpha transparency value.