### PR TITLE
lottieitem : Fix layer alpha transparency issue.

### DIFF
--- a/inc/rlottiecommon.h
+++ b/inc/rlottiecommon.h
@@ -225,6 +225,7 @@ typedef struct LOTLayerNode {
 
     LOTMatteType mMatte;
     int          mVisible;
+    int          mAlpha;
 
 } LOTLayerNode;
 

--- a/src/lottie/lottieitem.cpp
+++ b/src/lottie/lottieitem.cpp
@@ -244,11 +244,14 @@ void LOTLayerItem::buildLayerNode()
         mLayerCNode->mNodeList.size = 0;
         mLayerCNode->mMatte = MatteNone;
         mLayerCNode->mVisible = 0;
+        mLayerCNode->mAlpha = 255;
         mLayerCNode->mClipPath.ptPtr = nullptr;
         mLayerCNode->mClipPath.elmPtr = nullptr;
         mLayerCNode->mClipPath.ptCount = 0;
         mLayerCNode->mClipPath.elmCount = 0;
     }
+    if (complexContent())
+       mLayerCNode->mAlpha = combinedAlpha() * 255;
     mLayerCNode->mVisible = visible();
     // update matte
     if (hasMatte()) {


### PR DESCRIPTION
When a layer has transparency, we need to send it to layer node.
So I add mAlpha member to the LOTLayerItem.