### PR TITLE
rlottie: Refactor Rle Generation to optimize memory allocation.

### DIFF
--- a/src/lottie/lottieitem.h
+++ b/src/lottie/lottieitem.h
@@ -81,8 +81,7 @@ public:
 public:
     VSize                    mSize;
     VPath                    mPath;
-    RleShare                 mRleFuture;
-    VRle                     mRle;
+    VRasterizer              mRasterizer;
 };
 
 typedef vFlag<DirtyFlagBit> DirtyFlag;
@@ -215,8 +214,8 @@ public:
     VMatrix                  mCombinedMatrix;
     VPath                    mLocalPath;
     VPath                    mFinalPath;
-    RleShare                 mRleFuture;
-    VRle                     mRle;
+    VRasterizer              mRasterizer;
+    bool                     mRasterRequest{false};
 };
 
 /*

--- a/src/vector/vdrawable.h
+++ b/src/vector/vdrawable.h
@@ -57,10 +57,9 @@ public:
         CapStyle           cap{CapStyle::Flat};
         JoinStyle          join{JoinStyle::Bevel};
     };
+    VRasterizer       mRasterizer;
     VBrush            mBrush;
     VPath             mPath;
-    RleShare          mRleFuture;
-    VRle              mRle;
     StrokeInfo        mStroke;
     DirtyFlag         mFlag{DirtyState::All};
     FillRule          mFillRule{FillRule::Winding};

--- a/src/vector/vraster.h
+++ b/src/vector/vraster.h
@@ -27,50 +27,18 @@ V_BEGIN_NAMESPACE
 class VPath;
 class VRle;
 
-template <class R>
-class VSharedState {
+class VRasterizer
+{
 public:
-    void set_value(R value) {
-        if (_ready) return;
-
-        {
-            std::lock_guard<std::mutex> lock(_mutex);
-            _value = std::move(value);
-            _ready = true;
-        }
-        _cv.notify_one();
-    }
-    R get(){
-        std::unique_lock<std::mutex> lock(_mutex);
-        while(!_ready) _cv.wait(lock);
-        _valid = false;
-        return std::move(_value);
-    }
-    bool valid() const {return _valid;}
-    void reuse() {
-        _ready = false;
-        _valid = true;
-    }
+    void rasterize(VPath path, FillRule fillRule = FillRule::Winding, const VRect &clip = VRect());
+    void rasterize(VPath path, CapStyle cap, JoinStyle join, float width,
+                   float meterLimit, const VRect &clip = VRect());
+    VRle rle();
 private:
-    R                        _value;
-    std::mutex               _mutex;
-    std::condition_variable  _cv;
-    bool                     _ready{false};
-    bool                     _valid{false};
-};
-
-using RleShare = std::shared_ptr<VSharedState<VRle>>;
-
-struct VRaster {
-
-    static void
-    generateFillInfo(RleShare &promise, VPath &&path, VRle &&rle,
-                     FillRule fillRule = FillRule::Winding, const VRect &clip = VRect());
-
-    static void
-    generateStrokeInfo(RleShare &promise, VPath &&path, VRle &&rle,
-                       CapStyle cap, JoinStyle join,
-                       float width, float meterLimit, const VRect &clip = VRect());
+    struct VRasterizerImpl;
+    void init();
+    void updateRequest();
+    std::shared_ptr<VRasterizerImpl> d{nullptr};
 };
 
 V_END_NAMESPACE


### PR DESCRIPTION
Moved the Rle Generation to Rasterizer class which will take care of
handling async rle generation efficiently by reusing Task.
Now Rle Task scheduler will take a shared_ptr to the Task data which will
be created once in Rasterizer.