### PR TITLE
rlottie: Fix issue with Line join(Miter) by using the implementation …

### DIFF
--- a/src/vector/vraster.cpp
+++ b/src/vector/vraster.cpp
@@ -155,7 +155,7 @@ void FTOutline::convert(CapStyle cap, JoinStyle join, float width,
         ftJoin = SW_FT_STROKER_LINEJOIN_ROUND;
         break;
     default:
-        ftJoin = SW_FT_STROKER_LINEJOIN_MITER;
+        ftJoin = SW_FT_STROKER_LINEJOIN_MITER_FIXED;
         break;
     }
 }


### PR DESCRIPTION
…similar to what PDF uses.

Freetype has 2 types of miter join SW_FT_STROKER_LINEJOIN_MITER_VARIABLE and SW_FT_STROKER_LINEJOIN_MITER_FIXED.
SW_FT_STROKER_LINEJOIN_MITER_FIXED is similar to what PostScrip and PDF generates.
SW_FT_STROKER_LINEJOIN_MITER_VARIABLE is similar to what XPS generates.