### PR TITLE
Iamage loader: include windows.h and not Windows.h

### DIFF
--- a/src/vector/vimageloader.cpp
+++ b/src/vector/vimageloader.cpp
@@ -4,7 +4,7 @@
 #ifndef WIN32
 #include <dlfcn.h>
 #else
-#include <Windows.h>
+#include <windows.h>
 #endif
 #include <cstring>
 


### PR DESCRIPTION
Indeed, when cross-compiling on Linux, which has a case
sensitive file system, and as minwg-w64 provides windows.h,
we must use lower case name for header files.