### PR TITLE
fix dirname() implementation of Windows in lottieloader.cpp

### DIFF
--- a/example/lottie2gif.cpp
+++ b/example/lottie2gif.cpp
@@ -110,11 +110,11 @@ public:
 
         baseName = absoloutePath;
 #ifdef _WIN32
-        char *base = strchr(baseName.data(), '/');
+        char *base = strrchr(baseName.data(), '/');
         if (base)
         {
             base++;
-            base = strchr(baseName.data(), '\\');
+            base = strrchr(baseName.data(), '\\');
             if (base) base++;
             else return 1;
         }

--- a/src/lottie/lottieloader.cpp
+++ b/src/lottie/lottieloader.cpp
@@ -71,6 +71,9 @@ public:
 static std::string dirname(const std::string &path)
 {
     const char *ptr = strrchr(path.c_str(), '/');
+#ifdef _WIN32
+    if (ptr) ptr = strrchr(ptr + 1, '\\');
+#endif
     int         len = int(ptr + 1 - path.c_str());  // +1 to include '/'
     return std::string(path, 0, len);
 }


### PR DESCRIPTION
Fix also basename() implementation by using strrchr() and not strchr()