### PR TITLE
meson: generate cmake config files

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -52,3 +52,22 @@ if get_option('test') == true
    subdir('test')
 endif
 
+
+
+cmake = import('cmake')
+cmake.write_basic_package_version_file(
+    version: meson.project_version(),
+    name: 'rlottie',
+)
+
+cmakeconf = configuration_data()
+cmakeconf.set('VERSION', meson.project_version())
+
+cmake.configure_package_config_file(
+    input: meson.current_source_dir() + '/cmake/rlottieConfig.cmake.in',
+    name: 'rlottie',
+    configuration: cmakeconf,
+)
+
+
+


### PR DESCRIPTION
cmake config files needed by cmake's find_package to able to find rlottie.