### PR TITLE
meson: Fix regression in library size

### DIFF
--- a/src/meson.build
+++ b/src/meson.build
@@ -1,16 +1,15 @@
+compiler_flags = ['-DLOT_BUILD']
+
 cc = meson.get_compiler('cpp')
-compiler_flags = []
 if (cc.get_id() != 'msvc')
-    compiler_flags = ['-fno-exceptions', '-fno-rtti',
-                      '-fno-unwind-tables' , '-fno-asynchronous-unwind-tables',
-                      '-Woverloaded-virtual', '-Wno-unused-parameter']
+    compiler_flags += ['-fno-exceptions', '-fno-rtti',
+                       '-fno-unwind-tables' , '-fno-asynchronous-unwind-tables',
+                       '-Woverloaded-virtual', '-Wno-unused-parameter']
 endif
 
 subdir('vector')
 subdir('lottie')
 subdir('binding')
-
-compiler_flags += ['-DLOT_BUILD=1']
 
 rlottie_lib_dep  = [ vector_dep, lottie_dep, binding_dep, dependency('threads')]
 

--- a/src/vector/stb/meson.build
+++ b/src/vector/stb/meson.build
@@ -1,8 +1,6 @@
 
 source_file = ['stb_image.cpp']
 
-compiler_flags = ['-DLOT_BUILD=1']
-
 if get_option('module') == true
     rlottie_image_loader_lib = shared_library('rlottie-image-loader',
                                               source_file,


### PR DESCRIPTION
As all the meson variables are in global scope the compiler_flags
in stb module reseted all the optimization flag set in the src directory
which increased the library size by 100KB.