### PR TITLE
Configure CMake to allow build static rlottie lib

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -7,10 +7,14 @@ if (NOT CMAKE_BUILD_TYPE)
     set(CMAKE_BUILD_TYPE MinSizeRel)
 endif()
 
-add_definitions(-DLOT_BUILD)
+if (NOT DEFINED BUILD_SHARED_LIBS)
+    # Keep the previous behavior of the build system, consistent with Meson.
+    set(BUILD_SHARED_LIBS ON)
+endif()
 
 #declare target
-add_library( rlottie SHARED  "" )
+add_library( rlottie )
+set_target_properties( rlottie PROPERTIES DEFINE_SYMBOL LOT_BUILD )
 
 #declare version of the target
 set(player_version_major 0)
@@ -64,10 +68,10 @@ target_link_libraries(rlottie
                         "${CMAKE_THREAD_LIBS_INIT}"
                      )
 
-# for dlopen, dlsym and dlclose dependancy
-target_link_libraries(rlottie
-                    PRIVATE
-                    ${CMAKE_DL_LIBS})
+if (LOTTIE_MODULE)
+    # for dlopen, dlsym and dlclose dependancy
+    target_link_libraries(rlottie PRIVATE ${CMAKE_DL_LIBS})
+endif()
 
 if(APPLE)
     target_link_libraries(rlottie

--- a/src/vector/stb/CMakeLists.txt
+++ b/src/vector/stb/CMakeLists.txt
@@ -2,6 +2,12 @@ if(LOTTIE_MODULE)
     add_library(rlottie-image-loader SHARED
                 stb_image.cpp
                )
+    target_compile_options(rlottie-image-loader PRIVATE
+                           -fvisibility=hidden
+                          )
+    set_target_properties(rlottie-image-loader PROPERTIES
+                          DEFINE_SYMBOL LOT_BUILD
+                         )
     install(TARGETS rlottie-image-loader
             LIBRARY DESTINATION ${LIB_INSTALL_DIR}
             ARCHIVE DESTINATION ${LIB_INSTALL_DIR}


### PR DESCRIPTION
Also fix several little issues:

 * Do not define the LOT_BUILD global macro. Use instead the DEFINE_SYMBOL target property.
 * Add the `-fvisibility=hidden` compiler flag for the image loader. It seems to be forgotten by mistake.