### PR TITLE
Fix linking with static Qt.

### DIFF
--- a/src/vector/vcompositionfunctions.cpp
+++ b/src/vector/vcompositionfunctions.cpp
@@ -22,7 +22,7 @@
   result = s
   dest = s * ca + d * cia
 */
-void comp_func_solid_Source(uint32_t *dest, int length, uint32_t color,
+static void comp_func_solid_Source(uint32_t *dest, int length, uint32_t color,
                             uint32_t const_alpha)
 {
     int ialpha, i;
@@ -45,7 +45,8 @@ void comp_func_solid_Source(uint32_t *dest, int length, uint32_t color,
        = s * ca + d * (1 - sa*ca)
        = s' + d ( 1 - s'a)
 */
-void comp_func_solid_SourceOver(uint32_t *dest, int length, uint32_t color,
+static void comp_func_solid_SourceOver(uint32_t *dest, int length,
+                                       uint32_t color,
                                 uint32_t const_alpha)
 {
     int ialpha, i;
@@ -87,7 +88,7 @@ static void comp_func_solid_DestinationOut(uint *dest, int length, uint color,
     }
 }
 
-void comp_func_Source(uint32_t *dest, const uint32_t *src, int length,
+static void comp_func_Source(uint32_t *dest, const uint32_t *src, int length,
                       uint32_t const_alpha)
 {
     if (const_alpha == 255) {
@@ -104,7 +105,8 @@ void comp_func_Source(uint32_t *dest, const uint32_t *src, int length,
 /* s' = s * ca
  * d' = s' + d (1 - s'a)
  */
-void comp_func_SourceOver(uint32_t *dest, const uint32_t *src, int length,
+static void comp_func_SourceOver(uint32_t *dest, const uint32_t *src,
+                                 int length,
                           uint32_t const_alpha)
 {
     uint s, sia;
@@ -131,7 +133,7 @@ void comp_func_SourceOver(uint32_t *dest, const uint32_t *src, int length,
     }
 }
 
-void comp_func_DestinationIn(uint *dest, const uint *src, int length,
+static void comp_func_DestinationIn(uint *dest, const uint *src, int length,
                              uint const_alpha)
 {
     if (const_alpha == 255) {
@@ -147,7 +149,7 @@ void comp_func_DestinationIn(uint *dest, const uint *src, int length,
     }
 }
 
-void comp_func_DestinationOut(uint *dest, const uint *src, int length,
+static void comp_func_DestinationOut(uint *dest, const uint *src, int length,
                               uint const_alpha)
 {
     if (const_alpha == 255) {

--- a/src/vector/vdrawhelper.cpp
+++ b/src/vector/vdrawhelper.cpp
@@ -914,32 +914,32 @@ void vInitDrawhelperFunctions()
 
 #if defined(__ARM_NEON__)
     // update fast path for NEON
-    extern void comp_func_solid_SourceOver_neon(
+    extern void Vcomp_func_solid_SourceOver_neon(
         uint32_t * dest, int length, uint32_t color, uint32_t const_alpha);
 
     COMP_functionForModeSolid_C[VPainter::CompModeSrcOver] =
-        comp_func_solid_SourceOver_neon;
+        Vcomp_func_solid_SourceOver_neon;
 #endif
 
 #if defined(__SSE2__)
     // update fast path for SSE2
-    extern void comp_func_solid_SourceOver_sse2(
+    extern void Vcomp_func_solid_SourceOver_sse2(
         uint32_t * dest, int length, uint32_t color, uint32_t const_alpha);
-    extern void comp_func_solid_Source_sse2(
+    extern void Vcomp_func_solid_Source_sse2(
         uint32_t * dest, int length, uint32_t color, uint32_t const_alpha);
-    extern void comp_func_Source_sse2(uint32_t * dest, const uint32_t *src,
+    extern void Vcomp_func_Source_sse2(uint32_t * dest, const uint32_t *src,
                                       int length, uint32_t const_alpha);
-    extern void comp_func_SourceOver_sse2(uint32_t * dest, const uint32_t *src,
+    extern void Vcomp_func_SourceOver_sse2(uint32_t * dest, const uint32_t *src,
                                           int length, uint32_t const_alpha);
 
     COMP_functionForModeSolid_C[VPainter::CompModeSrc] =
-        comp_func_solid_Source_sse2;
+        Vcomp_func_solid_Source_sse2;
     COMP_functionForModeSolid_C[VPainter::CompModeSrcOver] =
-        comp_func_solid_SourceOver_sse2;
+        Vcomp_func_solid_SourceOver_sse2;
 
-    COMP_functionForMode_C[VPainter::CompModeSrc] = comp_func_Source_sse2;
+    COMP_functionForMode_C[VPainter::CompModeSrc] = Vcomp_func_Source_sse2;
     // COMP_functionForMode_C[VPainter::CompModeSrcOver] =
-    // comp_func_SourceOver_sse2;
+    // Vcomp_func_SourceOver_sse2;
 #endif
 }
 

--- a/src/vector/vdrawhelper_neon.cpp
+++ b/src/vector/vdrawhelper_neon.cpp
@@ -17,7 +17,8 @@ void memfill32(uint32_t *dest, uint32_t value, int length)
     pixman_composite_src_n_8888_asm_neon(length, 1, dest, length, value);
 }
 
-void comp_func_solid_SourceOver_neon(uint32_t *dest, int length, uint32_t color,
+void Vcomp_func_solid_SourceOver_neon(uint32_t *dest, int length,
+                                      uint32_t color,
                                      uint32_t const_alpha)
 {
     if (const_alpha != 255) color = BYTE_MUL(color, const_alpha);

--- a/src/vector/vdrawhelper_sse2.cpp
+++ b/src/vector/vdrawhelper_sse2.cpp
@@ -196,7 +196,7 @@ inline static void comp_func_helper_sse2(uint32_t* dest, int length,
                        })
 }
 
-void comp_func_solid_Source_sse2(uint32_t* dest, int length, uint32_t color,
+void Vcomp_func_solid_Source_sse2(uint32_t* dest, int length, uint32_t color,
                                  uint32_t const_alpha)
 {
     if (const_alpha == 255) {
@@ -210,7 +210,8 @@ void comp_func_solid_Source_sse2(uint32_t* dest, int length, uint32_t color,
     }
 }
 
-void comp_func_solid_SourceOver_sse2(uint32_t* dest, int length, uint32_t color,
+void Vcomp_func_solid_SourceOver_sse2(uint32_t* dest, int length,
+                                      uint32_t color,
                                      uint32_t const_alpha)
 {
     int ialpha;
@@ -220,7 +221,7 @@ void comp_func_solid_SourceOver_sse2(uint32_t* dest, int length, uint32_t color,
     comp_func_helper_sse2(dest, length, color, ialpha);
 }
 
-void comp_func_Source_sse2(uint32_t* dest, const uint32_t* src, int length,
+void Vcomp_func_Source_sse2(uint32_t* dest, const uint32_t* src, int length,
                            uint32_t const_alpha)
 {
     int ialpha;
@@ -439,7 +440,7 @@ static force_inline uint32_t core_combine_over_u_pixel_sse2(uint32_t src,
 // core_combine_over_u_sse2_no_mask (uint32_t *	  pd,
 //                  const uint32_t*    ps,
 //                  int                w)
-void comp_func_SourceOver_sse2(uint32_t* pd, const uint32_t* ps, int w,
+void Vcomp_func_SourceOver_sse2(uint32_t* pd, const uint32_t* ps, int w,
                                uint32_t)
 {
     uint32_t s, d;


### PR DESCRIPTION
This allows linking rlottie statically with statically linked Qt library that has the same global methods defined.