### PR TITLE
vdasher: fixed regression from last commit

### DIFF
--- a/src/vector/vdasher.cpp
+++ b/src/vector/vdasher.cpp
@@ -37,9 +37,9 @@ VDasher::VDasher(const float *dashArray, size_t size)
     // segments or ZERO lengths gaps we could
     // optimize those usecase.
     for (size_t i = 0; i < mArraySize; i++) {
-        if (!vCompare(mDashArray->length, 0.0f))
+        if (!vCompare(mDashArray[i].length, 0.0f))
             mNoLength = false;
-        if (!vCompare(mDashArray->gap, 0.0f))
+        if (!vCompare(mDashArray[i].gap, 0.0f))
             mNoGap = false;
     }
 }


### PR DESCRIPTION
this was only comparing the 1st dashinfo because of missing array subscript operator.