### PR TITLE
vdasher: refactor dash property parsing and handling.

### DIFF
--- a/src/lottie/lottieitem.h
+++ b/src/lottie/lottieitem.h
@@ -454,8 +454,7 @@ private:
    LOTProxyModel<LOTStrokeData> mModel;
    VColor                       mColor;
    float                        mWidth{0};
-   float                        mDashArray[6];
-   int                          mDashArraySize{0};
+   std::vector<float>           mDashInfo;
 };
 
 class LOTGStrokeItem : public LOTPaintDataItem
@@ -474,8 +473,7 @@ private:
    VColor                        mColor;
    float                         mAlpha{1.0};
    float                         mWidth{0};
-   float                         mDashArray[6];
-   int                           mDashArraySize{0};
+   std::vector<float>            mDashInfo;
 };
 
 

--- a/src/lottie/lottiemodel.cpp
+++ b/src/lottie/lottiemodel.cpp
@@ -135,43 +135,27 @@ VMatrix TransformData::matrix(int frameNo, bool autoOrient) const
     return m;
 }
 
-int LOTStrokeData::getDashInfo(int frameNo, float *array) const
+void LOTDashProperty::getDashInfo(int frameNo, std::vector<float>& result) const
 {
-    if (!mDash.mDashCount) return 0;
-    // odd case
-    if (mDash.mDashCount % 2) {
-        for (int i = 0; i < mDash.mDashCount; i++) {
-            array[i] = mDash.mDashArray[i].value(frameNo);
-        }
-        return mDash.mDashCount;
-    } else {  // even case when last gap info is not provided.
-        int i;
-        for (i = 0; i < mDash.mDashCount - 1; i++) {
-            array[i] = mDash.mDashArray[i].value(frameNo);
-        }
-        array[i] = array[i - 1];
-        array[i + 1] = mDash.mDashArray[i].value(frameNo);
-        return mDash.mDashCount + 1;
-    }
-}
+    result.clear();
 
-int LOTGStrokeData::getDashInfo(int frameNo, float *array) const
-{
-    if (!mDash.mDashCount) return 0;
-    // odd case
-    if (mDash.mDashCount % 2) {
-        for (int i = 0; i < mDash.mDashCount; i++) {
-            array[i] = mDash.mDashArray[i].value(frameNo);
-        }
-        return mDash.mDashCount;
-    } else {  // even case when last gap info is not provided.
-        int i;
-        for (i = 0; i < mDash.mDashCount - 1; i++) {
-            array[i] = mDash.mDashArray[i].value(frameNo);
-        }
-        array[i] = array[i - 1];
-        array[i + 1] = mDash.mDashArray[i].value(frameNo);
-        return mDash.mDashCount + 1;
+    if (mData.empty()) return;
+
+    if (result.capacity() < mData.size()) result.reserve(mData.size() + 1);
+
+    for (const auto &elm : mData)
+        result.push_back(elm.value(frameNo));
+
+    // if the size is even then we are missing last
+    // gap information which is same as the last dash value
+    // copy it from the last dash value.
+    // NOTE: last value is the offset and last-1 is the last dash value.
+    auto size = result.size();
+    if ((size % 2) == 0) {
+        //copy offset value to end.
+        result.push_back(result.back());
+        // copy dash value to gap.
+        result[size-1] = result[size-2];
     }
 }
 

--- a/src/lottie/lottieparser.cpp
+++ b/src/lottie/lottieparser.cpp
@@ -1567,7 +1567,7 @@ std::shared_ptr<LOTData> LottieParserImpl::parseStrokeObject()
         }
     }
     obj->setStatic(obj->mColor.isStatic() && obj->mOpacity.isStatic() &&
-                   obj->mWidth.isStatic() && obj->mDash.mStatic);
+                   obj->mWidth.isStatic() && obj->mDash.isStatic());
     return sharedStroke;
 }
 
@@ -1634,8 +1634,6 @@ std::shared_ptr<LOTData> LottieParserImpl::parseGFillObject()
 
 void LottieParserImpl::parseDashProperty(LOTDashProperty &dash)
 {
-    dash.mDashCount = 0;
-    dash.mStatic = true;
     RAPIDJSON_ASSERT(PeekType() == kArrayType);
     EnterArray();
     while (NextArrayValue()) {
@@ -1643,18 +1641,11 @@ void LottieParserImpl::parseDashProperty(LOTDashProperty &dash)
         EnterObject();
         while (const char *key = NextObjectKey()) {
             if (0 == strcmp(key, "v")) {
-                parseProperty(dash.mDashArray[dash.mDashCount++]);
+                dash.mData.emplace_back();
+                parseProperty(dash.mData.back());
             } else {
                 Skip(key);
             }
-        }
-    }
-
-    // update the staic proprty
-    for (int i = 0; i < dash.mDashCount; i++) {
-        if (!dash.mDashArray[i].isStatic()) {
-            dash.mStatic = false;
-            break;
         }
     }
 }
@@ -1688,7 +1679,7 @@ std::shared_ptr<LOTData> LottieParserImpl::parseGStrokeObject()
     }
 
     obj->setStatic(obj->isStatic() && obj->mWidth.isStatic() &&
-                   obj->mDash.mStatic);
+                   obj->mDash.isStatic());
     return sharedGStroke;
 }
 

--- a/src/lottie/lottieproxymodel.h
+++ b/src/lottie/lottieproxymodel.h
@@ -298,7 +298,9 @@ public:
     CapStyle capStyle() const {return _modelData->capStyle();}
     JoinStyle joinStyle() const {return _modelData->joinStyle();}
     bool hasDashInfo() const { return _modelData->hasDashInfo();}
-    int getDashInfo(int frameNo, float *array) const {return _modelData->getDashInfo(frameNo, array);}
+    void getDashInfo(int frameNo, std::vector<float>& result) const {
+        return _modelData->getDashInfo(frameNo, result);
+    }
 
 private:
     T                         *_modelData;

--- a/src/vector/vdasher.cpp
+++ b/src/vector/vdasher.cpp
@@ -187,7 +187,10 @@ void VDasher::cubicTo(const VPointF &cp1, const VPointF &cp2, const VPointF &e)
 
 VPath VDasher::dashed(const VPath &path)
 {
+    if (mNoLength && mNoGap) return path;
+
     if (path.empty() || mNoLength) return VPath();
+
     if (mNoGap) return path;
 
     mResult = {};

--- a/src/vector/vdrawable.cpp
+++ b/src/vector/vdrawable.cpp
@@ -59,13 +59,13 @@ void VDrawable::setStrokeInfo(CapStyle cap, JoinStyle join, float meterLimit,
     mFlag |= DirtyState::Path;
 }
 
-void VDrawable::setDashInfo(float *array, uint size)
+void VDrawable::setDashInfo(std::vector<float> &dashInfo)
 {
     bool hasChanged = false;
 
-    if (mStroke.mDash.size() == size) {
-        for (uint i = 0; i < size; i++) {
-            if (!vCompare(mStroke.mDash[i], array[i])) {
+    if (mStroke.mDash.size() == dashInfo.size()) {
+        for (uint i = 0; i < dashInfo.size(); i++) {
+            if (!vCompare(mStroke.mDash[i], dashInfo[i])) {
                 hasChanged = true;
                 break;
             }
@@ -76,11 +76,8 @@ void VDrawable::setDashInfo(float *array, uint size)
 
     if (!hasChanged) return;
 
-    mStroke.mDash.clear();
+    mStroke.mDash = dashInfo;
 
-    for (uint i = 0; i < size; i++) {
-        mStroke.mDash.push_back(array[i]);
-    }
     mFlag |= DirtyState::Path;
 }
 

--- a/src/vector/vdrawable.h
+++ b/src/vector/vdrawable.h
@@ -43,7 +43,7 @@ public:
     void setBrush(const VBrush &brush) { mBrush = brush; }
     void setStrokeInfo(CapStyle cap, JoinStyle join, float meterLimit,
                        float strokeWidth);
-    void setDashInfo(float *array, uint size);
+    void setDashInfo(std::vector<float> &dashInfo);
     void preprocess(const VRect &clip);
     VRle rle();
 


### PR DESCRIPTION
- reduce Stroke and GStroke model object size by keeping a vector instead of fixed array property.
- keep a vector instead of fixed size array in model.
- keep a vector instead of fix size array in shadow tree.
- refactor getDashInfo() to DashProperty class and reuse by both Stroke and GradientStroke model object.
- enable move constructor in LOTAnimatable class to support creation vector of objects.