### PR TITLE
optimization: read content of the file directly to std::string to avo…

### DIFF
--- a/src/lottie/lottieloader.cpp
+++ b/src/lottie/lottieloader.cpp
@@ -119,10 +119,15 @@ bool LottieLoader::load(const std::string &path, bool cachePolicy)
         vCritical << "failed to open file = " << path.c_str();
         return false;
     } else {
-        std::stringstream buf;
-        buf << f.rdbuf();
+        std::string content;
 
-        LottieParser parser(const_cast<char *>(buf.str().data()),
+        std::getline(f, content, '\0') ;
+        f.close();
+
+        if (content.empty()) return false;
+
+        const char *str = content.c_str();
+        LottieParser parser(const_cast<char *>(str),
                             dirname(path).c_str());
         mModel = parser.model();
 
@@ -130,8 +135,6 @@ bool LottieLoader::load(const std::string &path, bool cachePolicy)
 
         if (cachePolicy)
             LottieModelCache::instance().add(path, mModel);
-
-        f.close();
     }
 
     return true;


### PR DESCRIPTION
…id creating temporary memory.

As json format is one big string we can directly read the content of file with one call to getline()
without going through generic interface to first read into  stringstream and then create again a temorary
string from the stringstream buffer.