### PR TITLE
CAPI: Add capi to support the dynamic properties

### DIFF
--- a/inc/rlottie_capi.h
+++ b/inc/rlottie_capi.h
@@ -27,6 +27,19 @@
 extern "C" {
 #endif
 
+typedef enum {
+    LOTTIE_ANIMATION_PROPERTY_FILLCOLOR,      /*!< Color property of Fill object , value type is float [0 ... 1] */
+    LOTTIE_ANIMATION_PROPERTY_FILLOPACITY,    /*!< Opacity property of Fill object , value type is float [ 0 .. 100] */
+    LOTTIE_ANIMATION_PROPERTY_STROKECOLOR,    /*!< Color property of Stroke object , value type is float [0 ... 1] */
+    LOTTIE_ANIMATION_PROPERTY_STROKEOPACITY,  /*!< Opacity property of Stroke object , value type is float [ 0 .. 100] */
+    LOTTIE_ANIMATION_PROPERTY_STROKEWIDTH,    /*!< stroke with property of Stroke object , value type is float */
+    LOTTIE_ANIMATION_PROPERTY_TR_ANCHOR,      /*!< Transform Anchor property of Layer and Group object , value type is int */
+    LOTTIE_ANIMATION_PROPERTY_TR_POSITION,    /*!< Transform Position property of Layer and Group object , value type is int */
+    LOTTIE_ANIMATION_PROPERTY_TR_SCALE,       /*!< Transform Scale property of Layer and Group object , value type is float range[0 ..100] */
+    LOTTIE_ANIMATION_PROPERTY_TR_ROTATION,    /*!< Transform Scale property of Layer and Group object , value type is float. range[0 .. 360] in degrees*/
+    LOTTIE_ANIMATION_PROPERTY_TR_OPACITY      /*!< Transform Opacity property of Layer and Group object , value type is float [ 0 .. 100] */
+}Lottie_Animation_Property;
+
 typedef struct Lottie_Animation_S Lottie_Animation;
 
 /**
@@ -232,6 +245,34 @@ lottie_animation_render_async(Lottie_Animation *animation,
  */
 LOT_EXPORT uint32_t *
 lottie_animation_render_flush(Lottie_Animation *animation);
+
+
+/**
+ *  @brief Request to change the properties of this animation object.
+ *  Keypath should conatin object names separated by (.) and can handle globe(**) or wildchar(*)
+ *
+ *  @usage
+ *  To change fillcolor property of fill1 object in the layer1->group1->fill1 hirarchy to RED color
+ *
+ *      lottie_animation_property_override(animation, LOTTIE_ANIMATION_PROPERTY_FILLCOLOR, "layer1.group1.fill1", 1.0, 0.0, 0.0);
+ *
+ *  if all the color property inside group1 needs to be changed to GREEN color
+ *
+ *      lottie_animation_property_override(animation, LOTTIE_ANIMATION_PROPERTY_FILLCOLOR, "**.group1.**", 1.0, 0.0, 0.0);
+ *
+ *  @param[in] animation Animation object.
+ *  @param[in] type Property type. (@p Lottie_Animation_Property)
+ *  @param[in] keypath Specific content of target.
+ *  @param[in] ... Property values.
+ *
+ *  @ingroup Lottie_Animation
+ *  @internal
+ * */
+LOT_EXPORT void
+lottie_animation_property_override(Lottie_Animation *animation,
+                                   const Lottie_Animation_Property type,
+                                   const char *keypath,
+                                   ...);
 
 #ifdef __cplusplus
 }

--- a/src/binding/c/lottieanimation_capi.cpp
+++ b/src/binding/c/lottieanimation_capi.cpp
@@ -17,11 +17,14 @@
  */
 
 #include "rlottie.h"
+#include "rlottie_capi.h"
 #include "vdebug.h"
 
 using namespace rlottie;
 
 extern "C" {
+#include <string.h>
+#include <stdarg.h>
 
 struct Lottie_Animation_S
 {
@@ -148,4 +151,58 @@ lottie_animation_render_flush(Lottie_Animation_S *animation)
     return animation->mBufferRef;
 }
 
+LOT_EXPORT void
+lottie_animation_property_override(Lottie_Animation_S *animation,
+                                   const Lottie_Animation_Property type,
+                                   const char *keypath,
+                                   ...)
+{
+    va_list prop;
+    va_start(prop, keypath);
+
+    switch(type) {
+    case LOTTIE_ANIMATION_PROPERTY_FILLCOLOR: {
+        double r = va_arg(prop, double);
+        double g = va_arg(prop, double);
+        double b = va_arg(prop, double);
+        if (r > 1 || r < 0 || g > 1 || g < 0 || b > 1 || b < 0) break;
+        animation->mAnimation->setValue<rlottie::Property::FillColor>(keypath, rlottie::Color(r, g, b));
+        break;
+    }
+    case LOTTIE_ANIMATION_PROPERTY_FILLOPACITY: {
+        double opacity = va_arg(prop, double);
+        if (opacity > 100 || opacity < 0) break;
+        animation->mAnimation->setValue<rlottie::Property::FillOpacity>(keypath, (float)opacity);
+        break;
+    }
+    case LOTTIE_ANIMATION_PROPERTY_STROKECOLOR: {
+        double r = va_arg(prop, double);
+        double g = va_arg(prop, double);
+        double b = va_arg(prop, double);
+        if (r > 1 || r < 0 || g > 1 || g < 0 || b > 1 || b < 0) break;
+        animation->mAnimation->setValue<rlottie::Property::StrokeColor>(keypath, rlottie::Color(r, g, b));
+        break;
+    }
+    case LOTTIE_ANIMATION_PROPERTY_STROKEOPACITY: {
+        double opacity = va_arg(prop, double);
+        if (opacity > 100 || opacity < 0) break;
+        animation->mAnimation->setValue<rlottie::Property::StrokeOpacity>(keypath, (float)opacity);
+        break;
+    }
+    case LOTTIE_ANIMATION_PROPERTY_STROKEWIDTH: {
+        double width = va_arg(prop, double);
+        if (width < 0) break;
+        animation->mAnimation->setValue<rlottie::Property::StrokeWidth>(keypath, (float)width);
+        break;
+    }
+    case LOTTIE_ANIMATION_PROPERTY_TR_ANCHOR:
+    case LOTTIE_ANIMATION_PROPERTY_TR_POSITION:
+    case LOTTIE_ANIMATION_PROPERTY_TR_SCALE:
+    case LOTTIE_ANIMATION_PROPERTY_TR_ROTATION:
+    case LOTTIE_ANIMATION_PROPERTY_TR_OPACITY:
+        //@TODO handle propery update.
+        break;
+    }
+    va_end(prop);
+}
 }


### PR DESCRIPTION
 This function needs keypath and type of string type.
 And needs values as variable arguments.
 The usage of this function is written in docs.