### PR TITLE
Fix crash on invalid data.

### DIFF
--- a/src/lottie/lottieparser.cpp
+++ b/src/lottie/lottieparser.cpp
@@ -1119,7 +1119,9 @@ std::shared_ptr<LOTData> LottieParserImpl::parseGroupObject()
         staticFlag &= child.get()->isStatic();
     }
 
-    group->setStatic(staticFlag && group->mTransform->isStatic());
+    if (group->mTransform) {
+        group->setStatic(staticFlag && group->mTransform->isStatic());
+    }
 
     return sharedGroup;
 }


### PR DESCRIPTION
I'm not sure how this should be handled correctly, but in case of some invalid data currently it crashes with a null pointer dereference.