### PR TITLE
Check for layer parent-child cycles.

### DIFF
--- a/src/lottie/lottieitem.cpp
+++ b/src/lottie/lottieitem.cpp
@@ -68,6 +68,16 @@ static bool strokeProp(rlottie::Property prop)
     }
 }
 
+static bool isGoodParentLayer(LOTLayerItem *parent, LOTLayerItem *child) {
+    do {
+        if (parent == child) {
+            return false;
+        }
+        parent = parent->resolvedParentLayer();
+    } while (parent);
+    return true;
+}
+
 LOTCompItem::LOTCompItem(LOTModel *model)
     : mCurFrameNo(-1)
 {
@@ -435,7 +445,10 @@ LOTCompLayerItem::LOTCompLayerItem(LOTLayerData *layerModel)
             auto search =
                 std::find_if(mLayers.begin(), mLayers.end(),
                              [id](const auto &val) { return val->id() == id; });
-            if (search != mLayers.end()) layer->setParentLayer((*search).get());
+            if (search != mLayers.end() &&
+                isGoodParentLayer((*search).get(), layer.get())) {
+                layer->setParentLayer((*search).get());
+            }
         }
     }
 

--- a/src/lottie/lottieitem.h
+++ b/src/lottie/lottieitem.h
@@ -116,6 +116,7 @@ public:
    int id() const {return mLayerData->id();}
    int parentId() const {return mLayerData->parentId();}
    void setParentLayer(LOTLayerItem *parent){mParentLayer = parent;}
+   LOTLayerItem *resolvedParentLayer() const {return mParentLayer;}
    void setComplexContent(bool value) { mComplexContent = value;}
    bool complexContent() const {return mComplexContent;}
    virtual void update(int frameNo, const VMatrix &parentMatrix, float parentAlpha);


### PR DESCRIPTION
In case of bad input file there could be a cycle in parent-child relationship that leads to stack overflow crash. Simplest case is when the layer is made a parent to itself.