### PR TITLE
optimization: avoid memory allocation when shape data has animation k…

### DIFF
--- a/src/lottie/lottieitem.cpp
+++ b/src/lottie/lottieitem.cpp
@@ -173,10 +173,10 @@ void LOTMaskItem::update(int frameNo, const VMatrix &            parentMatrix,
 
     if (mData->mShape.isStatic()) {
         if (mLocalPath.empty()) {
-            mData->mShape.value(frameNo).toPath(mLocalPath);
+            mData->mShape.updatePath(frameNo, mLocalPath);
         }
     } else {
-        mData->mShape.value(frameNo).toPath(mLocalPath);
+        mData->mShape.updatePath(frameNo, mLocalPath);
     }
     /* mask item dosen't inherit opacity */
     mCombinedAlpha = mData->opacity(frameNo);
@@ -1044,7 +1044,7 @@ LOTShapeItem::LOTShapeItem(LOTShapeData *data)
 
 void LOTShapeItem::updatePath(VPath &path, int frameNo)
 {
-    mData->mShape.value(frameNo).toPath(path);
+    mData->mShape.updatePath(frameNo, path);
 }
 
 LOTPolystarItem::LOTPolystarItem(LOTPolystarData *data)


### PR DESCRIPTION
…eyframe.

because of generic LOTAnimatable interface when shape has animation data
we were always created temporary shape data duting lerp. by crating a specialization
of AnimatableShape data and directly updating path value during animation we avoid
lot of memory allocation and deallocation.