### PR TITLE
rlottie: lottie animation frame count behaviour change.

### DIFF
--- a/src/lottie/lottiemodel.h
+++ b/src/lottie/lottiemodel.h
@@ -669,7 +669,7 @@ public:
         return long(frameAtPos(timeInSec / duration()));
     }
     size_t totalFrame() const {return mEndFrame - mStartFrame;}
-    long frameDuration() const {return mEndFrame - mStartFrame -1;}
+    long frameDuration() const {return mEndFrame - mStartFrame;}
     float frameRate() const {return mFrameRate;}
     long startFrame() const {return mStartFrame;}
     long endFrame() const {return mEndFrame;}

--- a/src/lottie/lottieparser.cpp
+++ b/src/lottie/lottieparser.cpp
@@ -597,7 +597,10 @@ void LottieParserImpl::parseComposition()
     resolveLayerRefs();
     comp->setStatic(comp->mRootLayer->isStatic());
     comp->mRootLayer->mInFrame = comp->mStartFrame;
-    comp->mRootLayer->mOutFrame = comp->mEndFrame;
+    // increment outframe of the root layer by 1
+    // so that we can run the animation till endframe.
+    // the behaviour is consistant with the bodymovin player.
+    comp->mRootLayer->mOutFrame = comp->mEndFrame + 1;
 
     comp->mLayerInfoList = std::move(mLayerInfoList);
 


### PR DESCRIPTION
In bodymovin player the animation runs from inframe till outframe) but
we used to run the animation till outframe-1 as at outframe the animation
is invisible . We changed the behaviour to make it similar to bodymovin player.