### PR TITLE
Introduce export map to completely hide private symbols

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -68,6 +68,13 @@ target_link_libraries(rlottie
                         "${CMAKE_THREAD_LIBS_INIT}"
                      )
 
+if (NOT APPLE AND NOT WIN32)
+    target_link_libraries(rlottie
+                        PRIVATE
+                            "-Wl,--version-script=${CMAKE_SOURCE_DIR}/rlottie.expmap"
+                          )
+endif()
+
 if (LOTTIE_MODULE)
     # for dlopen, dlsym and dlclose dependancy
     target_link_libraries(rlottie PRIVATE ${CMAKE_DL_LIBS})

--- a/rlottie.expmap
+++ b/rlottie.expmap
@@ -1,0 +1,8 @@
+/* This version script for ld exposes only (r)lottie namespace. */
+{
+global:
+    lottie_*;
+    extern "C++" { rlottie::* };
+local:
+    *;
+};

--- a/src/lottie/lottieanimation.cpp
+++ b/src/lottie/lottieanimation.cpp
@@ -25,7 +25,7 @@
 
 using namespace rlottie;
 
-LOT_EXPORT void configureModelCacheSize(size_t cacheSize)
+LOT_EXPORT void rlottie::configureModelCacheSize(size_t cacheSize)
 {
     LottieLoader::configureModelCacheSize(cacheSize);
 }

--- a/src/meson.build
+++ b/src/meson.build
@@ -7,6 +7,11 @@ if (cc.get_id() != 'msvc')
                        '-Woverloaded-virtual', '-Wno-unused-parameter']
 endif
 
+linker_flags = []
+if (host_machine.system() not in ['darwin', 'windows'])
+    linker_flags += ['-Wl,--version-script=@0@/../rlottie.expmap'.format(meson.current_source_dir())]
+endif
+
 subdir('vector')
 subdir('lottie')
 subdir('binding')
@@ -19,6 +24,7 @@ rlottie_lib = library('rlottie',
                       dependencies          : rlottie_lib_dep,
                       install               : true,
                       cpp_args              : compiler_flags,
+                      link_args             : linker_flags,
                       gnu_symbol_visibility : 'hidden',
                      )
 


### PR DESCRIPTION
This prevents internal libstdc++ things from being visible outside the rlottie library. Look at all available symbols using the following command.

    nm --demangle --defined-only --dynamic librlottie.so

Also the commit puts configureModelCacheSize into the rlottie namespace that fixes a linker error against this function.