### PR TITLE
vector/ft: refactor to reduce branch miss.

### DIFF
--- a/src/vector/freetype/v_ft_math.cpp
+++ b/src/vector/freetype/v_ft_math.cpp
@@ -206,14 +206,16 @@ static void ft_trig_pseudo_rotate(SW_FT_Vector* vec, SW_FT_Angle theta)
 
     /* Pseudorotations, with right shifts */
     for (i = 1, b = 1; i < SW_FT_TRIG_MAX_ITERS; b <<= 1, i++) {
+        SW_FT_Fixed v1 = ((y + b) >> i);
+        SW_FT_Fixed v2 = ((x + b) >> i);
         if (theta < 0) {
-            xtemp = x + ((y + b) >> i);
-            y = y - ((x + b) >> i);
+            xtemp = x + v1;
+            y = y - v2;
             x = xtemp;
             theta += *arctanptr++;
         } else {
-            xtemp = x - ((y + b) >> i);
-            y = y + ((x + b) >> i);
+            xtemp = x - v1;
+            y = y + v2;
             x = xtemp;
             theta -= *arctanptr++;
         }
@@ -260,14 +262,16 @@ static void ft_trig_pseudo_polarize(SW_FT_Vector* vec)
 
     /* Pseudorotations, with right shifts */
     for (i = 1, b = 1; i < SW_FT_TRIG_MAX_ITERS; b <<= 1, i++) {
+        SW_FT_Fixed v1 = ((y + b) >> i);
+        SW_FT_Fixed v2 = ((x + b) >> i);
         if (y > 0) {
-            xtemp = x + ((y + b) >> i);
-            y = y - ((x + b) >> i);
+            xtemp = x + v1;
+            y = y - v2;
             x = xtemp;
             theta += *arctanptr++;
         } else {
-            xtemp = x - ((y + b) >> i);
-            y = y + ((x + b) >> i);
+            xtemp = x - v1;
+            y = y + v2;
             x = xtemp;
             theta -= *arctanptr++;
         }


### PR DESCRIPTION
vtune profile shows branch miss in ft_trig_pseudo_polarize and ft_trig_pseudo_rotate
as both the if cases does similar expensive computation move then to start so that
we will not pay high penalty during branch miss.