### PR TITLE
rlottie/opt: refactor renderList() api to return a Span to optimize t…

### DIFF
--- a/src/lottie/lottieitem_capi.cpp
+++ b/src/lottie/lottieitem_capi.cpp
@@ -69,11 +69,10 @@ void LOTShapeLayerItem::buildLayerNode()
 {
     LOTLayerItem::buildLayerNode();
 
-    mDrawableList.clear();
-    renderList(mDrawableList);
+    auto renderlist = renderList();
 
     cnodes().clear();
-    for (auto &i : mDrawableList) {
+    for (auto &i : renderlist) {
         auto lotDrawable = static_cast<LOTDrawable *>(i);
         lotDrawable->sync();
         cnodes().push_back(lotDrawable->mCNode.get());
@@ -152,11 +151,10 @@ void LOTSolidLayerItem::buildLayerNode()
 {
     LOTLayerItem::buildLayerNode();
 
-    mDrawableList.clear();
-    renderList(mDrawableList);
+    auto renderlist = renderList();
 
     cnodes().clear();
-    for (auto &i : mDrawableList) {
+    for (auto &i : renderlist) {
         auto lotDrawable = static_cast<LOTDrawable *>(i);
         lotDrawable->sync();
         cnodes().push_back(lotDrawable->mCNode.get());
@@ -169,11 +167,10 @@ void LOTImageLayerItem::buildLayerNode()
 {
     LOTLayerItem::buildLayerNode();
 
-    mDrawableList.clear();
-    renderList(mDrawableList);
+    auto renderlist = renderList();
 
     cnodes().clear();
-    for (auto &i : mDrawableList) {
+    for (auto &i : renderlist) {
         auto lotDrawable = static_cast<LOTDrawable *>(i);
         lotDrawable->sync();
 


### PR DESCRIPTION
…he LayerObject size"

previously renderList() was returning a vector by keeping a vector object which was adding to
the overal size of the layer objects. by changing to a simple span object now only shpelayer has to keep
the vector and rest of the layer object types don't have to.