### PR TITLE
rlottie: reduce polling count for task scheduler to 2.

### DIFF
--- a/src/lottie/lottieanimation.cpp
+++ b/src/lottie/lottieanimation.cpp
@@ -149,7 +149,7 @@ class RenderTaskScheduler {
         while (true) {
             bool             success = false;
             SharedRenderTask task;
-            for (unsigned n = 0; n != _count * 32; ++n) {
+            for (unsigned n = 0; n != _count * 2; ++n) {
                 if (_q[(i + n) % _count].try_pop(task)) {
                     success = true;
                     break;

--- a/src/vector/vraster.cpp
+++ b/src/vector/vraster.cpp
@@ -437,7 +437,7 @@ class RleTaskScheduler {
         while (true) {
             bool success = false;
 
-            for (unsigned n = 0; n != _count * 32; ++n) {
+            for (unsigned n = 0; n != _count * 2; ++n) {
                 if (_q[(i + n) % _count].try_pop(task)) {
                     success = true;
                     break;


### PR DESCRIPTION
when the queue is empty the thread tries to steal from other queue
and it was doing it 32 times .. changed it to 2 as it was spinning for
long time before going to  sleep. As we always give the tasks in batches
we can reduce the spin time.