### PR TITLE
rlottie: Supports the Transform Scale property.

### DIFF
--- a/example/demo.cpp
+++ b/example/demo.cpp
@@ -33,6 +33,7 @@ public:
         Demo3(app, filePath);
         Demo4(app, filePath);
         Demo5(app, filePath);
+        Demo6(app, filePath);
     }
     void Demo1(EvasApp *app, std::string &filePath) {
         /* Fill Color */
@@ -137,12 +138,32 @@ public:
         view5->loop(true);
         view5->setRepeatMode(LottieView::RepeatMode::Reverse);
     }
+
+    void Demo6(EvasApp *app, std::string &filePath) {
+        /* Transform scale */
+        view6.reset(new LottieView(app->evas()));
+        view6->setFilePath(filePath.c_str());
+        if (view6->player()) {
+            view6->player()->setValue<rlottie::Property::TrScale>("Shape Layer 1.Ellipse 1",
+                [](const rlottie::FrameInfo& info) {
+                          return rlottie::Size(100 - info.curFrame(),
+                                               50);
+                 });
+        }
+        view6->setPos(1500, 0);
+        view6->setSize(300, 300);
+        view6->show();
+        view6->play();
+        view6->loop(true);
+        view6->setRepeatMode(LottieView::RepeatMode::Reverse);
+    }
 private:
     std::unique_ptr<LottieView>  view1;
     std::unique_ptr<LottieView>  view2;
     std::unique_ptr<LottieView>  view3;
     std::unique_ptr<LottieView>  view4;
     std::unique_ptr<LottieView>  view5;
+    std::unique_ptr<LottieView>  view6;
 };
 
 static void
@@ -155,7 +176,7 @@ onExitCb(void *data, void */*extra*/)
 int
 main(void)
 {
-   EvasApp *app = new EvasApp(1500, 300);
+   EvasApp *app = new EvasApp(1800, 300);
    app->setup();
 
    std::string filePath = DEMO_DIR;

--- a/src/binding/c/lottieanimation_capi.cpp
+++ b/src/binding/c/lottieanimation_capi.cpp
@@ -210,8 +210,13 @@ lottie_animation_property_override(Lottie_Animation_S *animation,
         animation->mAnimation->setValue<rlottie::Property::TrPosition>(keypath, rlottie::Point((float)x, (float)y));
         break;
     }
+    case LOTTIE_ANIMATION_PROPERTY_TR_SCALE: {
+        double w = va_arg(prop, double);
+        double h = va_arg(prop, double);
+        animation->mAnimation->setValue<rlottie::Property::TrScale>(keypath, rlottie::Size((float)w, (float)h));
+        break;
+    }
     case LOTTIE_ANIMATION_PROPERTY_TR_ANCHOR:
-    case LOTTIE_ANIMATION_PROPERTY_TR_SCALE:
     case LOTTIE_ANIMATION_PROPERTY_TR_ROTATION:
     case LOTTIE_ANIMATION_PROPERTY_TR_OPACITY:
         //@TODO handle propery update.

--- a/src/lottie/lottieitem.cpp
+++ b/src/lottie/lottieitem.cpp
@@ -915,6 +915,10 @@ void LOTContentGroupItem::update(int frameNo, const VMatrix &parentMatrix,
         VMatrix m = mModel.transform()->matrix(frameNo);
         m *= parentMatrix;
 
+        if (mModel.filter().hasFilter(rlottie::Property::TrScale)){
+             auto sz = mModel.scale(frameNo);
+             m.scale(sz.width() / 100.0, sz.height() / 100.0);
+        }
         if (mModel.filter().hasFilter(rlottie::Property::TrPosition)){
              auto ps = mModel.position(frameNo);
              m.translate(ps.x(), ps.y());

--- a/src/lottie/lottieproxymodel.h
+++ b/src/lottie/lottieproxymodel.h
@@ -249,6 +249,12 @@ public:
         rlottie::Point pt = data(prop).point()(info);
         return VPointF(pt.x(), pt.y());
     }
+    VSize scale(rlottie::Property prop, int frame) const
+    {
+        rlottie::FrameInfo info(frame);
+        rlottie::Size sz = data(prop).size()(info);
+        return VSize(sz.w(), sz.h());
+    }
     float opacity(rlottie::Property prop, int frame) const
     {
         rlottie::FrameInfo info(frame);
@@ -355,6 +361,14 @@ public:
             return mFilter.point(rlottie::Property::TrPosition, frame);
         }
         return VPointF(_modelData->mTransform->matrix(frame).m_tx(), _modelData->mTransform->matrix(frame).m_ty());
+    }
+    VSize scale(int frame) const
+    {
+        if (mFilter.hasFilter(rlottie::Property::TrScale)) {
+            return mFilter.scale(rlottie::Property::TrScale, frame);
+        }
+        return VSize(_modelData->mTransform->matrix(frame).m_11() * 100.0,
+                       _modelData->mTransform->matrix(frame).m_22() * 100.0);
     }
 private:
     LOTGroupData               *_modelData;


### PR DESCRIPTION
Use setValue<rlottie::Property::TrScale> and return rlottie::Size type.

The default value of Size is 100. If it goes to zero it won't be visible.
If it is negative it will be flipped. If it is greater than 100, it will be enlarged.

Example) example/demo