### PR TITLE
lottie: Change dynamic property's transform order

### DIFF
--- a/src/lottie/lottieitem.cpp
+++ b/src/lottie/lottieitem.cpp
@@ -915,9 +915,9 @@ void LOTContentGroupItem::update(int frameNo, const VMatrix &parentMatrix,
         VMatrix m = mModel.transform()->matrix(frameNo);
         m *= parentMatrix;
 
-        if (mModel.filter().hasFilter(rlottie::Property::TrScale)){
-             auto sz = mModel.scale(frameNo);
-             m.scale(sz.width() / 100.0, sz.height() / 100.0);
+        if (mModel.filter().hasFilter(rlottie::Property::TrPosition)){
+             auto ps = mModel.position(frameNo);
+             m.translate(ps.x(), ps.y());
              newFlag |= DirtyFlagBit::Matrix;
         }
         if (mModel.filter().hasFilter(rlottie::Property::TrRotation)){
@@ -925,9 +925,9 @@ void LOTContentGroupItem::update(int frameNo, const VMatrix &parentMatrix,
              m.rotate(r);
              newFlag |= DirtyFlagBit::Matrix;
         }
-        if (mModel.filter().hasFilter(rlottie::Property::TrPosition)){
-             auto ps = mModel.position(frameNo);
-             m.translate(ps.x(), ps.y());
+        if (mModel.filter().hasFilter(rlottie::Property::TrScale)){
+             auto sz = mModel.scale(frameNo);
+             m.scale(sz.width() / 100.0, sz.height() / 100.0);
              newFlag |= DirtyFlagBit::Matrix;
         }
 


### PR DESCRIPTION
In lottie vmatrix the transform order is translate, rotate, scale.
Therefore, Change the order of the transforms applied to the dynamic property.