### PR TITLE
Expose name info of drawable node

### DIFF
--- a/inc/rlottiecommon.h
+++ b/inc/rlottiecommon.h
@@ -183,6 +183,8 @@ typedef struct LOTNode {
     int       mFlag;
     LOTBrushType mBrushType;
     LOTFillRule  mFillRule;
+
+    const char  *keypath;
 } LOTNode;
 
 

--- a/src/lottie/lottieitem.cpp
+++ b/src/lottie/lottieitem.cpp
@@ -1203,6 +1203,7 @@ void LOTPaintDataItem::addPathItems(std::vector<LOTPathDataItem *> &list,
 LOTFillItem::LOTFillItem(LOTFillData *data)
     : LOTPaintDataItem(data->isStatic()), mModel(data)
 {
+    mDrawable.setName(mModel.name());
 }
 
 bool LOTFillItem::updateContent(int frameNo, const VMatrix &, float alpha)
@@ -1220,6 +1221,7 @@ bool LOTFillItem::updateContent(int frameNo, const VMatrix &, float alpha)
 LOTGFillItem::LOTGFillItem(LOTGFillData *data)
     : LOTPaintDataItem(data->isStatic()), mData(data)
 {
+    mDrawable.setName(mData->name());
 }
 
 bool LOTGFillItem::updateContent(int frameNo, const VMatrix &matrix, float alpha)
@@ -1238,6 +1240,7 @@ bool LOTGFillItem::updateContent(int frameNo, const VMatrix &matrix, float alpha
 LOTStrokeItem::LOTStrokeItem(LOTStrokeData *data)
     : LOTPaintDataItem(data->isStatic()), mModel(data)
 {
+    mDrawable.setName(mModel.name());
     if (mModel.hasDashInfo()) {
         mDrawable.setType(VDrawable::Type::StrokeWithDash);
     } else {
@@ -1273,6 +1276,7 @@ bool LOTStrokeItem::updateContent(int frameNo, const VMatrix &matrix, float alph
 LOTGStrokeItem::LOTGStrokeItem(LOTGStrokeData *data)
     : LOTPaintDataItem(data->isStatic()), mData(data)
 {
+    mDrawable.setName(mData->name());
     if (mData->hasDashInfo()) {
         mDrawable.setType(VDrawable::Type::StrokeWithDash);
     } else {

--- a/src/lottie/lottieitem_capi.cpp
+++ b/src/lottie/lottieitem_capi.cpp
@@ -244,6 +244,7 @@ void LOTDrawable::sync()
         mCNode->mPath.ptPtr = ptPtr;
         mCNode->mPath.ptCount = 2 * pts.size();
         mCNode->mFlag |= ChangeFlagPath;
+        mCNode->keypath = name();
     }
 
     if (mStrokeInfo) {

--- a/src/vector/vdrawable.cpp
+++ b/src/vector/vdrawable.cpp
@@ -34,6 +34,7 @@ VDrawable::~VDrawable()
             delete mStrokeInfo;
         }
     }
+    if (mName) free(mName);
 }
 
 void VDrawable::setType(VDrawable::Type type)

--- a/src/vector/vdrawable.h
+++ b/src/vector/vdrawable.h
@@ -19,6 +19,7 @@
 #ifndef VDRAWABLE_H
 #define VDRAWABLE_H
 #include <future>
+#include <cstring>
 #include "vbrush.h"
 #include "vpath.h"
 #include "vrle.h"
@@ -54,6 +55,11 @@ public:
     void preprocess(const VRect &clip);
     void applyDashOp();
     VRle rle();
+    void setName(const char *name)
+    {
+        if (name) mName = strdup(name);
+    }
+    char* name() const { return mName; }
 
 public:
     struct StrokeInfo {
@@ -76,6 +82,8 @@ public:
     DirtyFlag                mFlag{DirtyState::All};
     FillRule                 mFillRule{FillRule::Winding};
     VDrawable::Type          mType{Type::Fill};
+
+    char                     *mName{nullptr};
 };
 
 #endif  // VDRAWABLE_H


### PR DESCRIPTION
We need to expose the ketpath corresponding to the 'Fill' and 'Stroke' content.
The drawable receives the name and passes it to the node of capi.
