### PR TITLE
vdrawable: Don't strdup for name data

### DIFF
--- a/src/vector/vdrawable.cpp
+++ b/src/vector/vdrawable.cpp
@@ -34,7 +34,6 @@ VDrawable::~VDrawable()
             delete mStrokeInfo;
         }
     }
-    if (mName) free(mName);
 }
 
 void VDrawable::setType(VDrawable::Type type)

--- a/src/vector/vdrawable.h
+++ b/src/vector/vdrawable.h
@@ -57,9 +57,9 @@ public:
     VRle rle();
     void setName(const char *name)
     {
-        if (name) mName = strdup(name);
+        mName = name;
     }
-    char* name() const { return mName; }
+    const char* name() const { return mName; }
 
 public:
     struct StrokeInfo {
@@ -83,7 +83,7 @@ public:
     FillRule                 mFillRule{FillRule::Winding};
     VDrawable::Type          mType{Type::Fill};
 
-    char                     *mName{nullptr};
+    const char              *mName{nullptr};
 };
 
 #endif  // VDRAWABLE_H


### PR DESCRIPTION
The name information passed in is allocated and managed by the parser.
There is no need to duplicate the same data.