### PR TITLE
lottie/parser: Avoid creating the shape data instance repeatedly in C…

### DIFF
--- a/src/lottie/lottieparser.cpp
+++ b/src/lottie/lottieparser.cpp
@@ -949,11 +949,8 @@ void LottieParserImpl::parseCharDataShape(VPath &obj)
 
                             while (const char *ksKey = NextObjectKey()) {
                                  if (0 == strcmp(ksKey, "k")) {
-                                      LottieShapeData shapeData;
-
-                                      getValue(shapeData);
-                                      shapeData.toPath(pathItem);
-                                      obj.addPath(pathItem);
+                                      parsePathInfo();
+                                      mPathInfo.updatePath(obj);
                                  } else {
                                       Skip(ksKey);
                                  }


### PR DESCRIPTION
…harData parser

By calling parsePathInfo function which is newly added instead of calling getValue and toPath,
it could avoid creating the shape data instance repeatedly in the while block.