### PR TITLE
rlottie/api: Added loadFromData() api with ColorFilter support

### DIFF
--- a/inc/rlottie.h
+++ b/inc/rlottie.h
@@ -1,16 +1,16 @@
-/* 
+/*
  * Copyright (c) 2018 Samsung Electronics Co., Ltd. All rights reserved.
- * 
+ *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public
  * License as published by the Free Software Foundation; either
  * version 2.1 of the License, or (at your option) any later version.
- * 
+ *
  * This library is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
  * Lesser General Public License for more details.
- * 
+ *
  * You should have received a copy of the GNU Lesser General Public
  * License along with this library; if not, write to the Free Software
  * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
@@ -261,6 +261,9 @@ using MarkerList = std::vector<std::tuple<std::string, int , int>>;
 
 using LayerInfoList = std::vector<std::tuple<std::string, int , int>>;
 
+
+using ColorFilter = std::function<void(float &r , float &g, float &b)>;
+
 class LOT_EXPORT Animation {
 public:
 
@@ -300,6 +303,23 @@ public:
     static std::unique_ptr<Animation>
     loadFromData(std::string jsonData, const std::string &key,
                  const std::string &resourcePath="", bool cachePolicy=true);
+
+    /**
+     *  @brief Constructs an animation object from JSON string data and update.
+     *  the color properties using ColorFilter.
+
+     *  @param[in] jsonData The JSON string data.
+     *  @param[in] resourcePath the path will be used to search for external resource.
+     *  @param[in] filter The color filter that will be applied for each color property
+     *             found during parsing.
+
+     *  @return Animation object that can render the contents of the
+     *          Lottie resource represented by JSON string data.
+     *
+     *  @internal
+     */
+    static std::unique_ptr<Animation>
+    loadFromData(std::string jsonData, std::string resourcePath, ColorFilter filter);
 
     /**
      *  @brief Returns default framerate of the Lottie resource.

--- a/src/lottie/lottieanimation.cpp
+++ b/src/lottie/lottieanimation.cpp
@@ -256,8 +256,23 @@ std::unique_ptr<Animation> Animation::loadFromData(
     }
 
     LottieLoader loader;
-    if (loader.loadFromData(std::move(jsonData), key,
-                            (resourcePath.empty() ? " " : resourcePath), cachePolicy)) {
+    if (loader.loadFromData(std::move(jsonData), key, resourcePath, cachePolicy)) {
+        auto animation = std::unique_ptr<Animation>(new Animation);
+        animation->d->init(loader.model());
+        return animation;
+    }
+    return nullptr;
+}
+
+std::unique_ptr<Animation> Animation::loadFromData( std::string jsonData, std::string resourcePath, ColorFilter filter)
+{
+    if (jsonData.empty()) {
+        vWarning << "jason data is empty";
+        return nullptr;
+    }
+
+    LottieLoader loader;
+    if (loader.loadFromData(std::move(jsonData), std::move(resourcePath), std::move(filter))) {
         auto animation = std::unique_ptr<Animation>(new Animation);
         animation->d->init(loader.model());
         return animation;

--- a/src/lottie/lottieloader.cpp
+++ b/src/lottie/lottieloader.cpp
@@ -21,6 +21,7 @@
 
 #include <cstring>
 #include <fstream>
+#include <sstream>
 
 #ifdef LOTTIE_CACHE_SUPPORT
 
@@ -127,8 +128,7 @@ bool LottieLoader::load(const std::string &path, bool cachePolicy)
         if (content.empty()) return false;
 
         const char *str = content.c_str();
-        LottieParser parser(const_cast<char *>(str),
-                            dirname(path).c_str());
+        LottieParser parser(const_cast<char *>(str), dirname(path));
         mModel = parser.model();
 
         if (!mModel) return false;
@@ -140,16 +140,15 @@ bool LottieLoader::load(const std::string &path, bool cachePolicy)
     return true;
 }
 
-bool LottieLoader::loadFromData(std::string &&jsonData, const std::string &key,
-                                const std::string &resourcePath, bool cachePolicy)
+bool LottieLoader::loadFromData(std::string jsonData, const std::string &key,
+                                std::string resourcePath, bool cachePolicy)
 {
     if (cachePolicy) {
         mModel = LottieModelCache::instance().find(key);
         if (mModel) return true;
     }
 
-    LottieParser parser(const_cast<char *>(jsonData.c_str()),
-                        resourcePath.c_str());
+    LottieParser parser(const_cast<char *>(jsonData.c_str()), std::move(resourcePath));
     mModel = parser.model();
 
     if (!mModel) return false;
@@ -158,6 +157,14 @@ bool LottieLoader::loadFromData(std::string &&jsonData, const std::string &key,
         LottieModelCache::instance().add(key, mModel);
 
     return true;
+}
+
+bool LottieLoader::loadFromData(std::string jsonData, std::string resourcePath, ColorFilter filter)
+{
+    LottieParser parser(const_cast<char *>(jsonData.c_str()), std::move(resourcePath), std::move(filter));
+    mModel = parser.model();
+
+    return mModel ? true : false;
 }
 
 std::shared_ptr<LOTModel> LottieLoader::model()

--- a/src/lottie/lottieloader.h
+++ b/src/lottie/lottieloader.h
@@ -1,16 +1,16 @@
-/* 
+/*
  * Copyright (c) 2018 Samsung Electronics Co., Ltd. All rights reserved.
- * 
+ *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public
  * License as published by the Free Software Foundation; either
  * version 2.1 of the License, or (at your option) any later version.
- * 
+ *
  * This library is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
  * Lesser General Public License for more details.
- * 
+ *
  * You should have received a copy of the GNU Lesser General Public
  * License along with this library; if not, write to the Free Software
  * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
@@ -19,19 +19,21 @@
 #ifndef LOTTIELOADER_H
 #define LOTTIELOADER_H
 
-#include<sstream>
 #include<memory>
+#include <functional>
 
 class LOTModel;
 class LottieLoader
 {
 public:
+   using ColorFilter = std::function<void(float &, float &, float&)>;
    static void configureModelCacheSize(size_t cacheSize);
    bool load(const std::string &filePath, bool cachePolicy);
-   bool loadFromData(std::string &&jsonData, const std::string &key,
-                     const std::string &resourcePath, bool cachePolicy);
+   bool loadFromData(std::string jsonData, const std::string &key,
+                     std::string resourcePath, bool cachePolicy);
+   bool loadFromData(std::string jsonData, std::string resourcePath, ColorFilter filter);
    std::shared_ptr<LOTModel> model();
-private:  
+private:
    std::shared_ptr<LOTModel>    mModel;
 };
 

--- a/src/lottie/lottieparser.cpp
+++ b/src/lottie/lottieparser.cpp
@@ -169,8 +169,10 @@ protected:
 
 class LottieParserImpl : public LookaheadParserHandler {
 public:
-    LottieParserImpl(char *str, const char *dir_path)
-        : LookaheadParserHandler(str), mDirPath(dir_path) {}
+    LottieParserImpl(char *str, std::string dir_path, ColorFilter filter)
+        : LookaheadParserHandler(str),
+          mColorFilter(std::move(filter)),
+          mDirPath(std::move(dir_path)) {}
     bool VerifyType();
     bool ParseNext();
 public:
@@ -263,6 +265,7 @@ public:
     void resolveLayerRefs();
     void parsePathInfo();
 private:
+    ColorFilter mColorFilter;
     struct {
         std::vector<VPointF>                       mInPoint;  /* "i" */
         std::vector<VPointF>                       mOutPoint; /* "o" */
@@ -1840,6 +1843,9 @@ void LottieParserImpl::getValue(LottieColor &color)
             val[i++] = value;
         }
     }
+
+    if (mColorFilter) mColorFilter( val[0] , val[1], val[2]) ;
+
     color.r = val[0];
     color.g = val[1];
     color.b = val[2];
@@ -2331,8 +2337,8 @@ public:
 #endif
 
 LottieParser::~LottieParser() = default;
-LottieParser::LottieParser(char *str, const char *dir_path)
-    : d(std::make_unique<LottieParserImpl>(str, dir_path))
+LottieParser::LottieParser(char *str, std::string dir_path, ColorFilter filter)
+    : d(std::make_unique<LottieParserImpl>(str, std::move(dir_path), std::move(filter)))
 {
     if (d->VerifyType())
         d->parseComposition();

--- a/src/lottie/lottieparser.h
+++ b/src/lottie/lottieparser.h
@@ -1,16 +1,16 @@
-/* 
+/*
  * Copyright (c) 2018 Samsung Electronics Co., Ltd. All rights reserved.
- * 
+ *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public
  * License as published by the Free Software Foundation; either
  * version 2.1 of the License, or (at your option) any later version.
- * 
+ *
  * This library is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
  * Lesser General Public License for more details.
- * 
+ *
  * You should have received a copy of the GNU Lesser General Public
  * License along with this library; if not, write to the Free Software
  * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
@@ -21,12 +21,14 @@
 
 #include "lottiemodel.h"
 #include <memory>
+#include <functional>
 
+using ColorFilter = std::function<void(float &, float &, float &)>;
 class LottieParserImpl;
 class LottieParser {
 public:
     ~LottieParser();
-    LottieParser(char* str, const char *dir_path);
+    LottieParser(char* str, std::string dir_path, ColorFilter filter = {});
     std::shared_ptr<LOTModel> model();
 private:
    std::unique_ptr<LottieParserImpl>  d;


### PR DESCRIPTION
Some usecase needs to apply the color filter during parsing for theme
support.
Ex: Same resource can be used for different theme with different colorfilter
    which will update the color pallet according to the theme.