### PR TITLE
text/model: small optimization patch for model and item

### DIFF
--- a/src/lottie/lottieitem.cpp
+++ b/src/lottie/lottieitem.cpp
@@ -858,18 +858,17 @@ renderer::TextLayer::TextLayer(model::Layer *layerData, VArenaAlloc *allocator)
 
 void renderer::TextLayer::updateContent()
 {
-    std::vector<LottieTextPath> textPathList;
     model::TextData             data;
     float                       curX = 0., curY = 0.;
     int                         index = 0, numOfIndex;
 
     mRenderNode.clear();
 
-    getTextPath(textPathList, frameNo());
+    updateTextPath(frameNo());
     getTextData(data, frameNo());
     numOfIndex = data.charAnimPropList.size();
 
-    for (auto &textPath : textPathList) {
+    for (auto &charPath : mCharPathList) {
         VMatrix m;
         float strokeWidthScale;
         auto &  charAnimProp = data.charAnimPropList.at(index++);
@@ -879,14 +878,14 @@ void renderer::TextLayer::updateContent()
         // performance.
         if (numOfIndex == index) index--;
 
-        m.translate(curX + textPath.x_advance / 2. * data.fontSize / 100. +
+        m.translate(curX + charPath.x_advance / 2. * data.fontSize / 100. +
                         charAnimProp.position.x(),
                     curY + charAnimProp.position.y());
         m.rotate(charAnimProp.rotation);
         curX +=
-            textPath.x_advance * data.fontSize / 100. + charAnimProp.tracking;
+            charPath.x_advance * data.fontSize / 100. + charAnimProp.tracking;
         m.translate(-charAnimProp.anchor -
-                    VPointF(textPath.x_advance / 2. * data.fontSize / 100., 0));
+                    VPointF(charPath.x_advance / 2. * data.fontSize / 100., 0));
         m.scale(charAnimProp.scale.x() / 100.,
                 charAnimProp.scale.y() / 100.);
         m = m * combinedMatrix();
@@ -896,17 +895,17 @@ void renderer::TextLayer::updateContent()
         m.scale(data.fontSize / 100.,
                 data.fontSize / 100.);
 
-        textPath.path.transform(m);
+        charPath.path.transform(m);
 
         if (!data.strokeOverFill && (charAnimProp.strokeWidth != 0)) {
-            doStroke(textPath.path, charAnimProp.strokeColor,
+            doStroke(charPath.path, charAnimProp.strokeColor,
                      charAnimProp.opacity, charAnimProp.strokeWidth, strokeWidthScale);
         }
 
-        doFill(textPath.path, charAnimProp.fillColor, charAnimProp.opacity);
+        doFill(charPath.path, charAnimProp.fillColor, charAnimProp.opacity);
 
         if (data.strokeOverFill && (charAnimProp.strokeWidth != 0)) {
-            doStroke(textPath.path, charAnimProp.strokeColor,
+            doStroke(charPath.path, charAnimProp.strokeColor,
                      charAnimProp.opacity, charAnimProp.strokeWidth, strokeWidthScale);
         }
     }

--- a/src/lottie/lottieitem.h
+++ b/src/lottie/lottieitem.h
@@ -331,7 +331,7 @@ protected:
     void updateContent() final;
 };
 
-class LottieTextPath {
+class CharPath {
 public:
     VPath path;
     float x_advance;
@@ -352,10 +352,12 @@ protected:
     model::TextDocument   curTextDocument;
     std::vector<std::unique_ptr<Drawable>> mRenderNode;
     std::vector<VDrawable *>               mDrawableList;
-    std::vector<LottieTextPath>            mLastTextPathList;
+    std::vector<CharPath>                  mCharPathList;
 
-    void getTextPath(std::vector<LottieTextPath> &textPathList, int frameNo)
+    void updateTextPath(int frameNo)
     {
+        mCharPathList.clear();
+
         curTextDocument =
             mLayerData->extra()->textLayer()->getTextDocument(frameNo);
         if (mLayerData->extra()->mCompRef &&
@@ -367,18 +369,14 @@ protected:
                         (mLayerData->extra()->mCompRef->compareFontFamily(
                              curTextDocument.mFont, charData.mFontFamily) ==
                          0)) {
-                        textPathList.emplace_back();
-                        auto &textPath = textPathList.back();
+                        mCharPathList.emplace_back();
+                        auto &charPath = mCharPathList.back();
 
-                        for (auto shapeData : charData.mShapePathData) {
-                            textPath.path.addPath(shapeData);
-                            break;
-                        }
-                        textPath.x_advance = charData.mWidth;
+                        charPath.path = charData.mShapePathData;
+                        charPath.x_advance = charData.mWidth;
                     }
                 }
             }
-            mLastTextPathList = textPathList;
         }
     }
 

--- a/src/lottie/lottiemodel.h
+++ b/src/lottie/lottiemodel.h
@@ -665,7 +665,7 @@ public:
     std::string        mFontFamily;    /* fFamily */
     double             mSize;          /* size */
     double             mWidth;         /* w */
-    std::vector<VPath> mShapePathData; /* data */
+    VPath              mShapePathData; /* data */
 };
 
 class Layer;

--- a/src/lottie/lottieparser.cpp
+++ b/src/lottie/lottieparser.cpp
@@ -1017,15 +1017,7 @@ void LottieParserImpl::parseCharData(model::Chars &obj)
             RAPIDJSON_ASSERT(PeekType() == kArrayType);
             EnterArray();
             while (NextArrayValue()) {
-                // obj.mShapesData.emplace_back();
-                // model::PathData &shapeDataObj = obj.mShapesData.back();
-                //
-                // parseCharDataShape(shapeDataObj);
-
-                obj.mShapePathData.emplace_back();
-                VPath &pathObj = obj.mShapePathData.back();
-
-                parseCharDataShape(pathObj);
+                parseCharDataShape(obj.mShapePathData);
             }
         } else {
             printf("parseCharData - UNKNOWN KEY!\n");


### PR DESCRIPTION
Just keep one VPath for embedded character's path data instead of list of VPath.
It also renames some functions and classes in text/item.