### PR TITLE
perf: added tAtLength(len, totalLength) api to Bezier.

### DIFF
--- a/src/lottie/lottiemodel.h
+++ b/src/lottie/lottiemodel.h
@@ -185,7 +185,7 @@ struct Value<VPointF> {
             VBezier b =
                 VBezier::fromPoints(mStartValue, mOutTangent,
                                     mInTangent, mEndValue);
-            return b.pointAt(b.tAtLength(t * mBezierLength));
+            return b.pointAt(b.tAtLength(t * mBezierLength, mBezierLength));
         }
         return lerp(mStartValue, mEndValue, t);
     }
@@ -196,7 +196,7 @@ struct Value<VPointF> {
             VBezier b =
                 VBezier::fromPoints(mStartValue, mOutTangent,
                                     mInTangent, mEndValue);
-            return b.angleAt(b.tAtLength(t * mBezierLength));
+            return b.angleAt(b.tAtLength(t * mBezierLength, mBezierLength));
         }
         return 0;
     }

--- a/src/vector/vbezier.cpp
+++ b/src/vector/vbezier.cpp
@@ -79,12 +79,11 @@ VBezier VBezier::onInterval(float t0, float t1) const
     return result;
 }
 
-float VBezier::tAtLength(float l) const
+float VBezier::tAtLength(float l, float totalLength) const
 {
-    float       len = length();
     float       t = 1.0;
     const float error = 0.01f;
-    if (l > len || vCompare(l, len)) return t;
+    if (l > totalLength || vCompare(l, totalLength)) return t;
 
     t *= 0.5;
 

--- a/src/vector/vbezier.h
+++ b/src/vector/vbezier.h
@@ -39,7 +39,8 @@ public:
                               const VPointF &cp2, const VPointF &end);
     inline void    parameterSplitLeft(float t, VBezier *left);
     inline void    split(VBezier *firstHalf, VBezier *secondHalf) const;
-    float          tAtLength(float len) const;
+    float          tAtLength(float len) const { return tAtLength(len , length());}
+    float          tAtLength(float len, float totalLength) const;
     void           splitAtLength(float len, VBezier *left, VBezier *right);
     VPointF        pt1() const { return {x1, y1}; }
     VPointF        pt2() const { return {x2, y2}; }


### PR DESCRIPTION
When length of the bezier is known , then pass it to tAtLength function
to avoid doing expensive length() operation again.