### PR TITLE
Fix MSVC 2019 static build

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -46,7 +46,7 @@ target_include_directories(rlottie
         "${CMAKE_CURRENT_BINARY_DIR}"
     )
 
-#declare target compilation options
+#declare common target compilation options
 target_compile_options(rlottie
                     PUBLIC
                     PRIVATE
@@ -56,13 +56,25 @@ target_compile_options(rlottie
                         -fno-asynchronous-unwind-tables
                         -fno-rtti
                         -Wall
-                        -Werror
-                        -Wextra
-                        -Wnon-virtual-dtor
-                        -Woverloaded-virtual
-                        -Wno-unused-parameter
                         -fvisibility=hidden
                     )
+
+#MSVC does not recognize these parameters
+if (NOT WIN32)
+    target_compile_options(rlottie
+                        PUBLIC
+                        PRIVATE
+                            -Werror
+                            -Wextra
+                            -Wnon-virtual-dtor
+                            -Woverloaded-virtual
+                            -Wno-unused-parameter
+                        )
+endif()
+
+if (WIN32 AND NOT BUILD_SHARED_LIBS)
+    target_compile_definitions(rlottie PUBLIC -DLOT_BUILD=0)
+endif()
 
 #declare dependancy
 set( CMAKE_THREAD_PREFER_PTHREAD TRUE )


### PR DESCRIPTION
Trying to build rlottie static in Microsoft Visual Studio 2019.
To do so `LOT_BUILD` must be undefined expliciltly in cmake call like ` -DCMAKE_CXX_FLAGS='-DLOT_BUILD=0'`
Added it to CMake file for simplicity, so only ` -DBUILD_SHARED_LIBS=OFF` will be enough.

Also moved some compiler parameters under `NOT WIN32` because MSVC can't recognize them and stops the compilation