### PR TITLE
parser: Fix the keyframe cache logic.

### DIFF
--- a/src/lottie/lottiemodel.h
+++ b/src/lottie/lottiemodel.h
@@ -165,8 +165,8 @@ struct Value<VPointF> {
     VPointF mEndValue;
     VPointF mInTangent;
     VPointF mOutTangent;
-    float   mBezierLength;
-    bool    mPathKeyFrame = false;
+    float   mBezierLength{0};
+    bool    mPathKeyFrame{false};
 
     void cache() {
         if (mPathKeyFrame) {
@@ -267,6 +267,8 @@ public:
                  (last < prevFrame && last < curFrame));
     }
 
+    void cache() {  for (auto &e : mKeyFrames) e.mValue.cache(); }
+
 public:
     std::vector<KeyFrame<T>> mKeyFrames;
 };
@@ -358,6 +360,7 @@ public:
         return isStatic() ? false : animation().changed(prevFrame, curFrame);
     }
 
+    void cache() { if (!isStatic()) animation().cache();}
 private:
     template <typename Tp>
     void construct(Tp &member, Tp &&val)

--- a/src/lottie/lottieparser.cpp
+++ b/src/lottie/lottieparser.cpp
@@ -2078,8 +2078,7 @@ void LottieParserImpl::parseKeyFrame(model::DynamicProperty<T> &obj)
             inTangent, outTangent, std::move(parsed.interpolatorKey));
         list.push_back(std::move(keyframe));
     } else {
-        // Last frame. cache some computaion
-        for (auto &e : list) e.mValue.cache();
+        // Last frame ignore
     }
 }
 
@@ -2116,6 +2115,7 @@ void LottieParserImpl::parseShapeProperty(model::Property<model::PathData> &obj)
             Skip(nullptr);
         }
     }
+    obj.cache();
 }
 
 template <typename T>
@@ -2155,6 +2155,7 @@ void LottieParserImpl::parsePropertyHelper(model::Property<T> &obj)
                 break;
             }
         }
+        obj.cache();
     }
 }
 


### PR DESCRIPTION
For some keyframes the cache function was not getting called.
so move the cache logic to outer function and call it when the property
is fully parsed.