### PR TITLE
build: use shared_module instead of shared_library

### DIFF
--- a/src/vector/stb/meson.build
+++ b/src/vector/stb/meson.build
@@ -3,14 +3,14 @@ source_file = ['stb_image.cpp']
 
 if get_option('module') == true
     rlottie_image_loader_dir = get_option('moduledir') != '' ? get_option('moduledir') : get_option('libdir')
-    rlottie_image_loader_lib = shared_library('rlottie-image-loader',
-                                              source_file,
-                                              include_directories : [include_directories('.'), config_dir],
-                                              install : true,
-                                              install_dir : rlottie_image_loader_dir,
-                                              cpp_args : compiler_flags,
-                                              gnu_symbol_visibility : 'hidden',
-                                             )
+    rlottie_image_loader_lib = shared_module('rlottie-image-loader',
+                                             source_file,
+                                             include_directories : [include_directories('.'), config_dir],
+                                             install : true,
+                                             install_dir : rlottie_image_loader_dir,
+                                             cpp_args : compiler_flags,
+                                             gnu_symbol_visibility : 'hidden',
+                                            )
     cc = meson.get_compiler('cpp')
     stb_dep = cc.find_library('dl', required : false)
 else


### PR DESCRIPTION
see https://mesonbuild.com/Reference-manual.html#shared_module