### PR TITLE
Allow empty key in loadFromData

### DIFF
--- a/inc/rlottie.h
+++ b/inc/rlottie.h
@@ -305,8 +305,8 @@ public:
      *  @internal
      */
     static std::unique_ptr<Animation>
-    loadFromData(std::string jsonData, const std::string &key,
-                 const std::string &resourcePath="", bool cachePolicy=true);
+    loadFromData(std::string jsonData, const std::string &key = std::string(),
+                 const std::string &resourcePath = std::string(), bool cachePolicy=true);
 
     /**
      *  @brief Constructs an animation object from JSON string data and update.

--- a/src/lottie/lottieloader.cpp
+++ b/src/lottie/lottieloader.cpp
@@ -148,7 +148,7 @@ std::shared_ptr<model::Composition> model::loadFromData(
     std::string jsonData, const std::string &key, std::string resourcePath,
     bool cachePolicy)
 {
-    if (cachePolicy) {
+    if (cachePolicy && !key.empty()) {
         auto obj = ModelCache::instance().find(key);
         if (obj) return obj;
     }
@@ -156,7 +156,8 @@ std::shared_ptr<model::Composition> model::loadFromData(
     auto obj = internal::model::parse(const_cast<char *>(jsonData.c_str()),
                                       std::move(resourcePath));
 
-    if (obj && cachePolicy) ModelCache::instance().add(key, obj);
+    if (obj && cachePolicy && !key.empty())
+        ModelCache::instance().add(key, obj);
 
     return obj;
 }


### PR DESCRIPTION
In case we don't need to cache loaded animation. Check for key emptyness as added bonus.
It also can be achieved with cachePolicy=false, but it will require addtional to pass 4 arguments to method, instead if just one.
