### PR TITLE
/MT and /MTd for MSVC static build

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -71,6 +71,8 @@ endif()
 
 if (WIN32 AND NOT BUILD_SHARED_LIBS)
     target_compile_definitions(rlottie PUBLIC -DRLOTTIE_BUILD=0)
+    set(CMAKE_CXX_FLAGS_RELEASE "${CMAKE_CXX_FLAGS_RELEASE} /MT")
+    set(CMAKE_CXX_FLAGS_DEBUG "${CMAKE_CXX_FLAGS_DEBUG} /MTd")
 endif()
 
 #declare dependancy


### PR DESCRIPTION
Set correct Visual Studio settings [(link)](https://docs.microsoft.com/ru-ru/cpp/build/reference/md-mt-ld-use-run-time-library?view=vs-2019) for static build