### PR TITLE
Fixed build with GCC 11

### DIFF
--- a/src/vector/vrle.cpp
+++ b/src/vector/vrle.cpp
@@ -27,6 +27,7 @@
 #include <array>
 #include <cstdlib>
 #include <cstring>
+#include <limits>
 #include <vector>
 #include "vdebug.h"
 #include "vglobal.h"


### PR DESCRIPTION
Fixed build with GCC 11 by adding missing `limits` header.