### PR TITLE
Fix CMake build in subdirectory

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -85,7 +85,7 @@ target_link_libraries(rlottie
 if (NOT APPLE AND NOT WIN32)
     target_link_libraries(rlottie
                         PRIVATE
-                            "-Wl,--version-script=${CMAKE_SOURCE_DIR}/rlottie.expmap"
+                            "-Wl,--version-script=${CMAKE_CURRENT_SOURCE_DIR}/rlottie.expmap"
                           )
 endif()
 


### PR DESCRIPTION
When rlottie is added as a subdirectory in a not Apple and not Windows OS the build fails because it searches rlottie.expmap in the main project source directory
This fixes the problem