### PR TITLE
Remove link warnings on MSVC

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -100,7 +100,7 @@ if (NOT LOTTIE_ASAN)
                             PUBLIC
                                  "-Wl, -undefined error"
                               )
-    else()
+    elseif(NOT MSVC)
         target_link_libraries(rlottie
                             PUBLIC
                                  "-Wl,--no-undefined"


### PR DESCRIPTION
These link options make no sense on MSVC and results in warnings. This change removes the warning.

Generally I believe it is ill-advised to add public warnings to a library, instead the client project should be able to control their own warnings.