### PR TITLE
Optimize compatibility with windows

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,5 @@
+{
+    "files.associations": {
+        "vector": "cpp"
+    }
+}

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,5 +1,0 @@
-{
-    "files.associations": {
-        "vector": "cpp"
-    }
-}

--- a/inc/rlottie_capi.h
+++ b/inc/rlottie_capi.h
@@ -291,6 +291,17 @@ RLOTTIE_API const LOTMarkerList* lottie_animation_get_markerlist(Lottie_Animatio
  */
 RLOTTIE_API void lottie_configure_model_cache_size(size_t cacheSize);
 
+#ifdef LOTTIE_THREAD
+/**
+ *  @brief Stop RleTaskScheduler if LOTTIE_THREAD defined,
+ *  @usage
+ *  In Windows 7 multithreading mode, unloading rlottie.dll will cause the process to be stuck and unable to exit. 
+ *	You need to actively stop RleTaskScheduler before main return
+ *  @internal
+ * */
+RLOTTIE_API void lottie_stop_taskscheduler();
+#endif
+
 #ifdef __cplusplus
 }
 #endif

--- a/inc/rlottie_capi.h
+++ b/inc/rlottie_capi.h
@@ -296,7 +296,7 @@ RLOTTIE_API void lottie_configure_model_cache_size(size_t cacheSize);
  *  @brief Stop RleTaskScheduler if LOTTIE_THREAD defined,
  *  @usage
  *  In Windows 7 multithreading mode, unloading rlottie.dll will cause the process to be stuck and unable to exit. 
- *	You need to actively stop RleTaskScheduler before main return
+ *	You need to actively stop RleTaskScheduler before main return 
  *  @internal
  * */
 RLOTTIE_API void lottie_stop_taskscheduler();

--- a/inc/rlottie_capi.h
+++ b/inc/rlottie_capi.h
@@ -291,7 +291,7 @@ RLOTTIE_API const LOTMarkerList* lottie_animation_get_markerlist(Lottie_Animatio
  */
 RLOTTIE_API void lottie_configure_model_cache_size(size_t cacheSize);
 
-#ifdef LOTTIE_THREAD
+#if defined(_MSC_VER) || defined(__CYGWIN__)
 /**
  *  @brief Stop RleTaskScheduler if LOTTIE_THREAD defined,
  *  @usage

--- a/src/binding/c/lottieanimation_capi.cpp
+++ b/src/binding/c/lottieanimation_capi.cpp
@@ -23,6 +23,7 @@
 #include "rlottie.h"
 #include "rlottie_capi.h"
 #include "vdebug.h"
+#include "vraster.h"
 
 using namespace rlottie;
 
@@ -280,5 +281,13 @@ lottie_configure_model_cache_size(size_t cacheSize)
 {
    rlottie::configureModelCacheSize(cacheSize);
 }
+
+#ifdef LOTTIE_THREAD
+RLOTTIE_API 
+void lottie_stop_taskscheduler()
+{
+	VRasterizer::stop_taskscheduler();
+}
+#endif
 
 }

--- a/src/binding/c/lottieanimation_capi.cpp
+++ b/src/binding/c/lottieanimation_capi.cpp
@@ -282,7 +282,7 @@ lottie_configure_model_cache_size(size_t cacheSize)
    rlottie::configureModelCacheSize(cacheSize);
 }
 
-#ifdef LOTTIE_THREAD
+#if defined(_MSC_VER) || defined(__CYGWIN__)
 RLOTTIE_API 
 void lottie_stop_taskscheduler()
 {

--- a/src/vector/stb/stb_image.h
+++ b/src/vector/stb/stb_image.h
@@ -1164,8 +1164,12 @@ static FILE *stbi__fopen(char const *filename, char const *mode)
     MultiByteToWideChar(CP_UTF8, 0, mode, -1, modeU, cch);
 #if _MSC_VER >= 1400
     _wfopen_s(&f, filenameU, modeU);
+    delete[] filenameU;
+    delete[] modeU;
 #else // _MSC_VER >= 1400
     f = _wfopen(filenameU, modeU);
+    delete[] filenameU;
+    delete[] modeU;
 #endif // _MSC_VER >= 1400
 #else // _MSC_VER
     f = fopen(filename, mode);

--- a/src/vector/stb/stb_image.h
+++ b/src/vector/stb/stb_image.h
@@ -307,6 +307,10 @@ RECENT REVISION HISTORY:
 #include <stdio.h>
 #endif // STBI_NO_STDIO
 
+#if defined _WIN32 || defined __CYGWIN__
+#include <windows.h>
+#endif  // defined _WIN32 || defined __CYGWIN__
+
 #define STBI_VERSION 1
 
 enum
@@ -1149,14 +1153,24 @@ static void stbi__float_postprocess(float *result, int *x, int *y, int *comp, in
 
 static FILE *stbi__fopen(char const *filename, char const *mode)
 {
-   FILE *f;
-#if defined(_MSC_VER) && _MSC_VER >= 1400
-   if (0 != fopen_s(&f, filename, mode))
-      f=0;
-#else
-   f = fopen(filename, mode);
-#endif
-   return f;
+    FILE *f;
+#if defined(_MSC_VER)
+    DWORD cch =
+        MultiByteToWideChar(CP_UTF8, 0, filename, -1, nullptr, 0);
+    wchar_t *filenameU = new wchar_t[cch];
+    MultiByteToWideChar(CP_UTF8, 0, filename, -1, filenameU, cch);
+    cch = MultiByteToWideChar(CP_UTF8, 0, mode, -1, nullptr, 0);
+    wchar_t *modeU = new wchar_t[cch];
+    MultiByteToWideChar(CP_UTF8, 0, mode, -1, modeU, cch);
+#if _MSC_VER >= 1400
+    _wfopen_s(&f, filenameU, modeU);
+#else // _MSC_VER >= 1400
+    f = _wfopen(filenameU, modeU);
+#endif // _MSC_VER >= 1400
+#else // _MSC_VER
+    f = fopen(filename, mode);
+#endif //_MSC_VER
+    return f;
 }
 
 

--- a/src/vector/vraster.cpp
+++ b/src/vector/vraster.cpp
@@ -472,9 +472,6 @@ public:
 
     ~RleTaskScheduler()
     {
-        for (auto &e : _q) e.done();
-
-        for (auto &e : _threads) e.join();
     }
 
     void stop()

--- a/src/vector/vraster.cpp
+++ b/src/vector/vraster.cpp
@@ -477,15 +477,12 @@ public:
         #endif
     }
 
-#if defined(_MSC_VER) || defined(__CYGWIN__)
     void stop()
     {
         for (auto &e : _q) e.done();
 
         for (auto &e : _threads) e.join();
     }
-#endif
-
 
     void process(VTask task)
     {

--- a/src/vector/vraster.cpp
+++ b/src/vector/vraster.cpp
@@ -477,6 +477,14 @@ public:
         for (auto &e : _threads) e.join();
     }
 
+    void stop()
+    {
+        for (auto &e : _q) e.done();
+
+        for (auto &e : _threads) e.join();
+    }
+
+
     void process(VTask task)
     {
         auto i = _index++;
@@ -558,6 +566,11 @@ void VRasterizer::rasterize(VPath path, CapStyle cap, JoinStyle join,
     }
     d->task().update(std::move(path), cap, join, width, miterLimit, clip);
     updateRequest();
+}
+
+void VRasterizer::stop_taskscheduler()
+{
+    RleTaskScheduler::instance().stop();
 }
 
 V_END_NAMESPACE

--- a/src/vector/vraster.cpp
+++ b/src/vector/vraster.cpp
@@ -472,14 +472,19 @@ public:
 
     ~RleTaskScheduler()
     {
+        #if !defined(_MSC_VER) && !defined(__CYGWIN__)
+            stop();
+        #endif
     }
 
+#if defined(_MSC_VER) || defined(__CYGWIN__)
     void stop()
     {
         for (auto &e : _q) e.done();
 
         for (auto &e : _threads) e.join();
     }
+#endif
 
 
     void process(VTask task)
@@ -565,9 +570,11 @@ void VRasterizer::rasterize(VPath path, CapStyle cap, JoinStyle join,
     updateRequest();
 }
 
+#if defined(_MSC_VER) || defined(__CYGWIN__)
 void VRasterizer::stop_taskscheduler()
 {
     RleTaskScheduler::instance().stop();
 }
+#endif
 
 V_END_NAMESPACE

--- a/src/vector/vraster.h
+++ b/src/vector/vraster.h
@@ -38,7 +38,9 @@ public:
     void rasterize(VPath path, CapStyle cap, JoinStyle join, float width,
                    float miterLimit, const VRect &clip = VRect());
     VRle rle();
+#if defined(_MSC_VER) || defined(__CYGWIN__)
     static void stop_taskscheduler();
+#endif
 private:
     struct VRasterizerImpl;
     void init();

--- a/src/vector/vraster.h
+++ b/src/vector/vraster.h
@@ -38,6 +38,7 @@ public:
     void rasterize(VPath path, CapStyle cap, JoinStyle join, float width,
                    float miterLimit, const VRect &clip = VRect());
     VRle rle();
+    static void stop_taskscheduler();
 private:
     struct VRasterizerImpl;
     void init();


### PR DESCRIPTION
1.On windows, stbi__fopen opens a path containing non-English characters or symbols will fail due to encoding problems, so the filename parameter is assumed to be utf-8 and converted to utf-16, and then call _wfopen_s or _wfopen
2. In Windows 7 multithreading mode, unloading rlottie.dll will cause the process to be stuck and unable to exit. You need to actively stop RleTaskScheduler before main return
