### PR TITLE
dynamic unloading of library in multi threading scenario.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,4 @@ tmp
 .vs
 **/*.DS_Store
 builddir_wasm
+.vscode

--- a/inc/rlottie.h
+++ b/inc/rlottie.h
@@ -48,6 +48,13 @@ struct LOTLayerNode;
 namespace rlottie {
 
 /**
+ *  @brief clear lottie resource
+ *  @note You need to actively shutdown lottie before main return
+ *  @internal
+ * */
+RLOTTIE_API void shutdown();
+
+/**
  *  @brief Configures rlottie model cache policy.
  *
  *  Provides Library level control to configure model cache

--- a/inc/rlottie_capi.h
+++ b/inc/rlottie_capi.h
@@ -291,17 +291,15 @@ RLOTTIE_API const LOTMarkerList* lottie_animation_get_markerlist(Lottie_Animatio
  */
 RLOTTIE_API void lottie_configure_model_cache_size(size_t cacheSize);
 
-#if defined(_MSC_VER) || defined(__CYGWIN__)
+
 /**
- *  @brief Stop RleTaskScheduler if LOTTIE_THREAD defined,
- *  @usage
- *  In Windows 7 multithreading mode, unloading rlottie.dll will cause 
- *  the process to be stuck and unable to exit. You need to actively stop  
- *	RleTaskScheduler before main return
+ *  @brief clear global resource,
+ *  @note  You need to actively shutdown lottie before main return
  *  @internal
- * */
-RLOTTIE_API void lottie_stop_taskscheduler();
-#endif
+ * 
+ **/
+RLOTTIE_API void lottie_shutdown();
+
 
 #ifdef __cplusplus
 }

--- a/inc/rlottie_capi.h
+++ b/inc/rlottie_capi.h
@@ -291,6 +291,18 @@ RLOTTIE_API const LOTMarkerList* lottie_animation_get_markerlist(Lottie_Animatio
  */
 RLOTTIE_API void lottie_configure_model_cache_size(size_t cacheSize);
 
+#if defined(_MSC_VER) || defined(__CYGWIN__)
+/**
+ *  @brief Stop RleTaskScheduler if LOTTIE_THREAD defined,
+ *  @usage
+ *  In Windows 7 multithreading mode, unloading rlottie.dll will cause 
+ *  the process to be stuck and unable to exit. You need to actively stop  
+ *	RleTaskScheduler before main return
+ *  @internal
+ * */
+RLOTTIE_API void lottie_stop_taskscheduler();
+#endif
+
 #ifdef __cplusplus
 }
 #endif

--- a/src/binding/c/lottieanimation_capi.cpp
+++ b/src/binding/c/lottieanimation_capi.cpp
@@ -23,6 +23,7 @@
 #include "rlottie.h"
 #include "rlottie_capi.h"
 #include "vdebug.h"
+#include "vraster.h"
 
 using namespace rlottie;
 
@@ -280,5 +281,13 @@ lottie_configure_model_cache_size(size_t cacheSize)
 {
    rlottie::configureModelCacheSize(cacheSize);
 }
+
+#if defined(_MSC_VER) || defined(__CYGWIN__)
+RLOTTIE_API 
+void lottie_stop_taskscheduler()
+{
+	VRasterizer::stop_taskscheduler();
+}
+#endif
 
 }

--- a/src/binding/c/lottieanimation_capi.cpp
+++ b/src/binding/c/lottieanimation_capi.cpp
@@ -282,12 +282,10 @@ lottie_configure_model_cache_size(size_t cacheSize)
    rlottie::configureModelCacheSize(cacheSize);
 }
 
-#if defined(_MSC_VER) || defined(__CYGWIN__)
 RLOTTIE_API 
-void lottie_stop_taskscheduler()
+void lottie_shutdown()
 {
-	VRasterizer::stop_taskscheduler();
+    rlottie::shutdown();
 }
-#endif
 
 }

--- a/src/lottie/lottieanimation.cpp
+++ b/src/lottie/lottieanimation.cpp
@@ -34,6 +34,11 @@ RLOTTIE_API void rlottie::configureModelCacheSize(size_t cacheSize)
     internal::model::configureModelCacheSize(cacheSize);
 }
 
+RLOTTIE_API void rlottie::shutdown()
+{
+    VRasterizer::stop_taskscheduler();
+}
+
 struct RenderTask {
     RenderTask() { receiver = sender.get_future(); }
     std::promise<Surface> sender;

--- a/src/vector/vraster.cpp
+++ b/src/vector/vraster.cpp
@@ -472,9 +472,6 @@ public:
 
     ~RleTaskScheduler()
     {
-        #if !defined(_MSC_VER) && !defined(__CYGWIN__)
-            stop();
-        #endif
     }
 
     void stop()
@@ -569,11 +566,9 @@ void VRasterizer::rasterize(VPath path, CapStyle cap, JoinStyle join,
     updateRequest();
 }
 
-#if defined(_MSC_VER) || defined(__CYGWIN__)
 void VRasterizer::stop_taskscheduler()
 {
     RleTaskScheduler::instance().stop();
 }
-#endif
 
 V_END_NAMESPACE

--- a/src/vector/vraster.cpp
+++ b/src/vector/vraster.cpp
@@ -472,6 +472,13 @@ public:
 
     ~RleTaskScheduler()
     {
+        #if !defined(_MSC_VER) && !defined(__CYGWIN__)
+            stop();
+        #endif
+    }
+
+    void stop()
+    {
         for (auto &e : _q) e.done();
 
         for (auto &e : _threads) e.join();
@@ -508,6 +515,8 @@ public:
     RleTaskScheduler() { SW_FT_Stroker_New(&stroker); }
 
     ~RleTaskScheduler() { SW_FT_Stroker_Done(stroker); }
+
+    void stop() { }
 
     void process(VTask task) { (*task)(outlineRef, stroker); }
 };
@@ -559,5 +568,12 @@ void VRasterizer::rasterize(VPath path, CapStyle cap, JoinStyle join,
     d->task().update(std::move(path), cap, join, width, miterLimit, clip);
     updateRequest();
 }
+
+#if defined(_MSC_VER) || defined(__CYGWIN__)
+void VRasterizer::stop_taskscheduler()
+{
+    RleTaskScheduler::instance().stop();
+}
+#endif
 
 V_END_NAMESPACE

--- a/src/vector/vraster.h
+++ b/src/vector/vraster.h
@@ -38,9 +38,7 @@ public:
     void rasterize(VPath path, CapStyle cap, JoinStyle join, float width,
                    float miterLimit, const VRect &clip = VRect());
     VRle rle();
-    #if defined(_MSC_VER) || defined(__CYGWIN__)
     static void stop_taskscheduler();
-#endif
 private:
     struct VRasterizerImpl;
     void init();

--- a/src/vector/vraster.h
+++ b/src/vector/vraster.h
@@ -38,6 +38,9 @@ public:
     void rasterize(VPath path, CapStyle cap, JoinStyle join, float width,
                    float miterLimit, const VRect &clip = VRect());
     VRle rle();
+    #if defined(_MSC_VER) || defined(__CYGWIN__)
+    static void stop_taskscheduler();
+#endif
 private:
     struct VRasterizerImpl;
     void init();


### PR DESCRIPTION
In Windows 7 multithreading mode, unloading rlottie.dll will cause the process to be stuck and unable to exit. You need to actively stop RleTaskScheduler before main return