### PR TITLE
add the /inc folder as an include path at build time

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -41,6 +41,7 @@ set(LOTTIE_MODULE_PATH "${CMAKE_SHARED_LIBRARY_PREFIX}rlottie-image-loader${CMAK
 configure_file(${CMAKE_CURRENT_LIST_DIR}/cmake/config.h.in config.h)
 
 target_include_directories(rlottie
+    PUBLIC $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/inc>
     PRIVATE
         "${CMAKE_CURRENT_BINARY_DIR}"
     )


### PR DESCRIPTION
When rlottie is being used as a submodule and included with
```
add_subdirectory(rlottie)
target_link_libraries(example rlottie::rlottie)
```
this ensures the include path is correctly passed along.
The `BUILD_INTERFACE` generator leads to this being only available at build-time but not via the exported config that gets installed.