### PR TITLE
Skip dash array of size one or zero

### DIFF
--- a/src/lottie/lottiemodel.cpp
+++ b/src/lottie/lottiemodel.cpp
@@ -205,7 +205,7 @@ void model::Dash::getDashInfo(int frameNo, std::vector<float> &result) const
 {
     result.clear();
 
-    if (mData.empty()) return;
+    if (mData.size() <= 1) return;
 
     if (result.capacity() < mData.size()) result.reserve(mData.size() + 1);
 


### PR DESCRIPTION
An attempt to fix [CVE-2021-31317][1], not tested yet.

 [1]: https://www.shielder.it/advisories/telegram-rlottie-vdasher-vdasher-type-confusion/
