### PR TITLE
rlottie/capi: Add missing multiply for Path

### DIFF
--- a/src/lottie/lottieitem_capi.cpp
+++ b/src/lottie/lottieitem_capi.cpp
@@ -121,7 +121,7 @@ void renderer::Layer::buildLayerNode()
             auto        ptPtr = reinterpret_cast<const float *>(pts.data());
             auto        elmPtr = reinterpret_cast<const char *>(elm.data());
             cNode.mPath.ptPtr = ptPtr;
-            cNode.mPath.ptCount = pts.size();
+            cNode.mPath.ptCount = 2 * pts.size();
             cNode.mPath.elmPtr = elmPtr;
             cNode.mPath.elmCount = elm.size();
             cNode.mAlpha = uchar(mask.mCombinedAlpha * 255.0f);


### PR DESCRIPTION
mPath is std::vector array of VPointF as a VPath type.
Since the list of points is passed to the capi structure as a float*,
the size of the capi point list is twice the length of the vector array.

issue :https://github.com/Samsung/rlottie/issues/489