### PR TITLE
lottiemodel: Improve opacity calculation for gradient stop

### DIFF
--- a/src/lottie/lottiemodel.h
+++ b/src/lottie/lottiemodel.h
@@ -821,6 +821,7 @@ public:
 
 private:
     void populate(VGradientStops &stops, int frameNo);
+    float getOpacityAtPosition(float *opacities, size_t opacityArraySize, float position);
 
 public:
     int                      mGradientType{1};    /* "t" Linear=1 , Radial = 2*/


### PR DESCRIPTION
Basically, Graeidnt stop's color and opacity are provided as separate arrays.
Stop position and opacity position do not match each other.
Existing code is a sequential approach. It caused problems in various cases of positions.
The improved logic repeats the loop, but no exceptions are raised. It's not complicated, it's simple.

This code referenced the lottie-android library.
https://github.com/airbnb/lottie-android/blob/master/lottie/src/main/java/com/airbnb/lottie/parser/GradientColorParser.java

test file
[test5.zip](https://github.com/Samsung/rlottie/files/7681472/test5.zip)

before
![image](https://user-images.githubusercontent.com/7413838/145316229-e3f1304d-e315-402f-bdeb-1695601b6bf3.png)

after
![image](https://user-images.githubusercontent.com/7413838/145316181-da71c25a-57e5-4294-87a4-8682d2dd810a.png)
