### PR TITLE
replace unsigned int with uint32_t in Int()

### DIFF
--- a/src/vector/vglobal.h
+++ b/src/vector/vglobal.h
@@ -139,7 +139,7 @@ public:
 
     using Int = typename std::conditional<
         std::is_unsigned<typename std::underlying_type<Enum>::type>::value,
-        unsigned int, signed int>::type;
+        uint32_t, signed int>::type;
 
     using  enum_type = Enum;
     // compiler-generated copy/move ctor/assignment operators are fine!


### PR DESCRIPTION
In some compiation platforms, uint32_t is not equivalent to unsigned int, resulting in compilation errors of overload ambiguous.