### PR TITLE
Add lottie_init() and lottie_shutdown() c api.

### DIFF
--- a/inc/rlottie_capi.h
+++ b/inc/rlottie_capi.h
@@ -47,6 +47,36 @@ typedef enum {
 typedef struct Lottie_Animation_S Lottie_Animation;
 
 /**
+ *  @brief Runs lottie initialization code when rlottie library is loaded
+ * dynamically.
+ *
+ *
+ * This api should be called before any other api when rlottie library
+ * is loaded using dlopen() or equivalent.
+ *
+ *  @see lottie_shutdown()
+ *
+ *  @ingroup Lottie_Animation
+ *  @internal
+ */
+RLOTTIE_API void lottie_init();
+
+/**
+ *  @brief Runs lottie teardown code when rlottie library  is loaded
+ * dynamically.
+ *
+ * This api should be called before unloading the rlottie library for
+ * proper cleanup of the resource without doing so will result in undefined
+ * behaviour.
+ *
+ *  @see lottie_init()
+ *
+ *  @ingroup Lottie_Animation
+ *  @internal
+ */
+RLOTTIE_API void lottie_shutdown();
+
+/**
  *  @brief Constructs an animation object from file path.
  *
  *  @param[in] path Lottie resource file path

--- a/src/binding/c/lottieanimation_capi.cpp
+++ b/src/binding/c/lottieanimation_capi.cpp
@@ -26,6 +26,9 @@
 
 using namespace rlottie;
 
+extern void lottie_init_impl();
+extern void lottie_shutdown_impl();
+
 extern "C" {
 #include <string.h>
 #include <stdarg.h>
@@ -37,6 +40,34 @@ struct Lottie_Animation_S
     uint32_t                       *mBufferRef;
     LOTMarkerList                  *mMarkerList;
 };
+
+static uint32_t _lottie_lib_ref_count = 0;
+
+RLOTTIE_API void lottie_init()
+{
+    if (_lottie_lib_ref_count > 0) {
+        _lottie_lib_ref_count++;
+        return;
+    }
+    lottie_init_impl();
+
+    _lottie_lib_ref_count = 1;
+}
+
+RLOTTIE_API void lottie_shutdown()
+{
+    if (_lottie_lib_ref_count <= 0) {
+        // lottie_init() is not called before lottie_shutdown()
+        // or multiple shutdown is getting called.
+        return;
+    }
+
+    _lottie_lib_ref_count--;
+
+    if (_lottie_lib_ref_count == 0) {
+        lottie_shutdown_impl();
+    }
+}
 
 RLOTTIE_API Lottie_Animation_S *lottie_animation_from_file(const char *path)
 {

--- a/src/vector/vraster.cpp
+++ b/src/vector/vraster.cpp
@@ -461,20 +461,29 @@ class RleTaskScheduler {
         for (unsigned n = 0; n != _count; ++n) {
             _threads.emplace_back([&, n] { run(n); });
         }
+
+        IsRunning = true;
     }
 
 public:
+    static bool IsRunning;
+
     static RleTaskScheduler &instance()
     {
         static RleTaskScheduler singleton;
         return singleton;
     }
 
-    ~RleTaskScheduler()
-    {
-        for (auto &e : _q) e.done();
+    ~RleTaskScheduler() { stop(); }
 
-        for (auto &e : _threads) e.join();
+    void stop()
+    {
+        if (IsRunning) {
+            IsRunning = false;
+
+            for (auto &e : _q) e.done();
+            for (auto &e : _threads) e.join();
+        }
     }
 
     void process(VTask task)
@@ -499,11 +508,15 @@ public:
     SW_FT_Stroker stroker;
 
 public:
+    static bool IsRunning;
+
     static RleTaskScheduler &instance()
     {
         static RleTaskScheduler singleton;
         return singleton;
     }
+
+    void stop() {}
 
     RleTaskScheduler() { SW_FT_Stroker_New(&stroker); }
 
@@ -512,6 +525,8 @@ public:
     void process(VTask task) { (*task)(outlineRef, stroker); }
 };
 #endif
+
+bool RleTaskScheduler::IsRunning{false};
 
 struct VRasterizer::VRasterizerImpl {
     VRleTask mTask;
@@ -558,6 +573,13 @@ void VRasterizer::rasterize(VPath path, CapStyle cap, JoinStyle join,
     }
     d->task().update(std::move(path), cap, join, width, miterLimit, clip);
     updateRequest();
+}
+
+void lottieShutdownRasterTaskScheduler()
+{
+    if (RleTaskScheduler::IsRunning) {
+        RleTaskScheduler::instance().stop();
+    }
 }
 
 V_END_NAMESPACE


### PR DESCRIPTION
To support dynamic loading and unloading of rlottie library safely
we need to deallocate the resource cache as well as safely shutdown all the
worker threads.
current patch only stops the Render and Rle task schedulers when lottie_shutdown is called.

Things yet to be implemented during shutdown phase
- Unload image loader if loaded dynamically.
- Check if we can release some cache resources.
- Currently multiple load and unload of rlottie library will not work as we are not starting the
  scheduler again when lottie_init() called multiple time in the same process.