### PR TITLE
add formal parameter void to lottie_init() and lottie_shutdown()

### DIFF
--- a/inc/rlottie_capi.h
+++ b/inc/rlottie_capi.h
@@ -59,7 +59,7 @@ typedef struct Lottie_Animation_S Lottie_Animation;
  *  @ingroup Lottie_Animation
  *  @internal
  */
-RLOTTIE_API void lottie_init();
+RLOTTIE_API void lottie_init(void);
 
 /**
  *  @brief Runs lottie teardown code when rlottie library  is loaded
@@ -74,7 +74,7 @@ RLOTTIE_API void lottie_init();
  *  @ingroup Lottie_Animation
  *  @internal
  */
-RLOTTIE_API void lottie_shutdown();
+RLOTTIE_API void lottie_shutdown(void);
 
 /**
  *  @brief Constructs an animation object from file path.

--- a/src/binding/c/lottieanimation_capi.cpp
+++ b/src/binding/c/lottieanimation_capi.cpp
@@ -43,7 +43,7 @@ struct Lottie_Animation_S
 
 static uint32_t _lottie_lib_ref_count = 0;
 
-RLOTTIE_API void lottie_init()
+RLOTTIE_API void lottie_init(void)
 {
     if (_lottie_lib_ref_count > 0) {
         _lottie_lib_ref_count++;
@@ -54,7 +54,7 @@ RLOTTIE_API void lottie_init()
     _lottie_lib_ref_count = 1;
 }
 
-RLOTTIE_API void lottie_shutdown()
+RLOTTIE_API void lottie_shutdown(void)
 {
     if (_lottie_lib_ref_count <= 0) {
         // lottie_init() is not called before lottie_shutdown()


### PR DESCRIPTION
When rlottie_capi.h is included in other C programs, a compilation error occurs. The error is  function declaration isn’t a prototype, so i create a PR to solve it.