### PR TITLE
Add support for partial rendering. 

### DIFF
--- a/inc/rlottie.h
+++ b/inc/rlottie.h
@@ -142,7 +142,7 @@ public:
      *  @brief Sets the Draw Area available on the Surface.
      *
      *  Lottie will use the draw region size to generate frame image
-     *  and will update only the draw rgion of the surface.
+     *  and will update only the draw region of the surface.
      *
      *  @param[in] x      region area x position.
      *  @param[in] y      region area y position.
@@ -420,6 +420,18 @@ public:
      *  @internal
      */
     void              renderSync(size_t frameNo, Surface surface, bool keepAspectRatio=true);
+
+    /**
+     *  @brief Renders the content to partial surface synchronously.
+     *         for performance use the async rendering @see render
+     *
+     *  @param[in] frameNo Content corresponds to the @p frameNo needs to be drawn
+     *  @param[in] surface Surface in which content will be drawn
+     *
+     *  @internal
+     */
+    void              renderPartialSync(size_t frameNo, Surface surface);
+
 
     /**
      *  @brief Returns root layer of the composition updated with

--- a/inc/rlottie_capi.h
+++ b/inc/rlottie_capi.h
@@ -202,6 +202,25 @@ RLOTTIE_API size_t lottie_animation_get_frame_at_pos(const Lottie_Animation *ani
 RLOTTIE_API void lottie_animation_render(Lottie_Animation *animation, size_t frame_num, uint32_t *buffer, size_t width, size_t height, size_t bytes_per_line);
 
 /**
+ *  @brief Request to render the content of the frame @p frame_num to buffer @p buffer.
+ *
+ *  @param[in] animation Animation object.
+ *  @param[in] frame_num the frame number needs to be rendered.
+ *  @param[in] buffer surface buffer use for rendering.
+ *  @param[in] width width of the surface
+ *  @param[in] height height of the surface
+ *  @param[in] top offset to render from
+ *  @param[in] bottom offset to render from
+ *  @param[in] bytes_per_line stride of the surface in bytes.
+ *
+ *
+ *  @ingroup Lottie_Animation
+ *  @internal
+ */
+RLOTTIE_API void lottie_animation_render_partial(Lottie_Animation *animation, size_t frame_num, uint32_t *buffer, size_t width, size_t height, size_t top, size_t bottom, size_t bytes_per_line);
+
+
+/**
  *  @brief Request to render the content of the frame @p frame_num to buffer @p buffer asynchronously.
  *
  *  @param[in] animation Animation object.

--- a/src/binding/c/lottieanimation_capi.cpp
+++ b/src/binding/c/lottieanimation_capi.cpp
@@ -138,6 +138,24 @@ lottie_animation_render(Lottie_Animation_S *animation,
 }
 
 RLOTTIE_API void
+lottie_animation_render_partial(Lottie_Animation_S *animation,
+                        size_t frame_number,
+                        uint32_t *buffer,
+                        size_t width,
+                        size_t height,
+                        size_t top,
+                        size_t bottom,
+                        size_t bytes_per_line)
+{
+    if (!animation) return;
+
+    rlottie::Surface surface(buffer, width, height, bytes_per_line);
+    surface.setDrawRegion(0, top, width, bottom - top);
+    animation->mAnimation->renderPartialSync(frame_number, surface);
+}
+
+
+RLOTTIE_API void
 lottie_animation_render_async(Lottie_Animation_S *animation,
                               size_t frame_number,
                               uint32_t *buffer,

--- a/src/lottie/lottieitem.cpp
+++ b/src/lottie/lottieitem.cpp
@@ -148,7 +148,7 @@ bool renderer::Composition::update(int frameNo, const VSize &size,
 }
 
 bool renderer::Composition::updatePartial(int frameNo, const VSize &size, 
-                                          const uint offset)
+                                          unsigned int offset)
 {
     // check if cached frame is same as requested frame.
     if ((mViewSize.width() == size.width()) && (mCurFrameNo == frameNo) && 

--- a/src/lottie/lottieitem.cpp
+++ b/src/lottie/lottieitem.cpp
@@ -147,6 +147,35 @@ bool renderer::Composition::update(int frameNo, const VSize &size,
     return true;
 }
 
+bool renderer::Composition::updatePartial(int frameNo, const VSize &size, 
+                                          const uint offset)
+{
+    // check if cached frame is same as requested frame.
+    if ((mViewSize.width() == size.width()) && (mCurFrameNo == frameNo) && 
+        (mOffset == offset))
+        return false;
+
+    mViewSize = size;
+    mCurFrameNo = frameNo;
+    mKeepAspectRatio = false;
+    mOffset = offset;
+
+    /*
+     * if viewbox dosen't scale exactly to the viewport
+     * we scale the viewbox keeping AspectRatioPreserved and then align the
+     * viewbox to the viewport using AlignCenter rule.
+     */
+    VMatrix m;
+    VSize   viewPort = mViewSize;
+    VSize   viewBox = mModel->size();
+    float   sx = float(viewPort.width()) / viewBox.width();
+    float   ty = offset;
+    m.translate(0, -ty).scale(sx, sx);
+
+    mRootLayer->update(frameNo, m, 1.0);
+    return true;
+}
+
 bool renderer::Composition::render(const rlottie::Surface &surface)
 {
     mSurface.reset(reinterpret_cast<uchar *>(surface.buffer()),
@@ -169,6 +198,30 @@ bool renderer::Composition::render(const rlottie::Surface &surface)
     painter.end();
     return true;
 }
+
+bool renderer::Composition::renderPartial(const rlottie::Surface &surface)
+{
+    mSurface.reset(reinterpret_cast<uchar *>(surface.buffer()),
+                   uint(surface.width()), uint(surface.drawRegionHeight()),
+                   uint(surface.bytesPerLine()),
+                   VBitmap::Format::ARGB32_Premultiplied);
+
+    /* schedule all preprocess task for this frame at once.
+     */
+    VRect clip(0, 0, int(surface.drawRegionWidth()),
+               int(surface.drawRegionHeight()));
+    mRootLayer->preprocess(clip);
+
+    VPainter painter(&mSurface);
+    // set sub surface area for drawing.
+    painter.setDrawRegion(
+        VRect(int(surface.drawRegionPosX()), 0,
+              int(surface.drawRegionWidth()), int(surface.drawRegionHeight())));
+    mRootLayer->render(&painter, {}, {}, mSurfaceCache);
+    painter.end();
+    return true;
+}
+
 
 void renderer::Mask::update(int frameNo, const VMatrix &parentMatrix,
                             float /*parentAlpha*/, const DirtyFlag &flag)

--- a/src/lottie/lottieitem.h
+++ b/src/lottie/lottieitem.h
@@ -191,7 +191,7 @@ class Composition {
 public:
     explicit Composition(std::shared_ptr<model::Composition> composition);
     bool  update(int frameNo, const VSize &size, bool keepAspectRatio);
-    bool  updatePartial(int frameNo, const VSize &size, uint offset);
+    bool  updatePartial(int frameNo, const VSize &size, unsigned int offset);
     VSize size() const { return mViewSize; }
     void  buildRenderTree();
     const LOTLayerNode *renderTree() const;
@@ -209,7 +209,7 @@ private:
     VArenaAlloc                         mAllocator{2048};
     int                                 mCurFrameNo;
     bool                                mKeepAspectRatio{true};
-    uint                                mOffset{0};
+    unsigned int                        mOffset{0};
 };
 
 class Layer {

--- a/src/lottie/lottieitem.h
+++ b/src/lottie/lottieitem.h
@@ -191,10 +191,12 @@ class Composition {
 public:
     explicit Composition(std::shared_ptr<model::Composition> composition);
     bool  update(int frameNo, const VSize &size, bool keepAspectRatio);
+    bool  updatePartial(int frameNo, const VSize &size, uint offset);
     VSize size() const { return mViewSize; }
     void  buildRenderTree();
     const LOTLayerNode *renderTree() const;
     bool                render(const rlottie::Surface &surface);
+    bool                renderPartial(const rlottie::Surface &surface);
     void                setValue(const std::string &keypath, LOTVariant &value);
 
 private:
@@ -207,6 +209,7 @@ private:
     VArenaAlloc                         mAllocator{2048};
     int                                 mCurFrameNo;
     bool                                mKeepAspectRatio{true};
+    uint                                mOffset{0};
 };
 
 class Layer {


### PR DESCRIPTION
This actually allows performing rendering in passes and does not require a `width * height * 4` bytes buffer anymore. 

On limited memory MCU, this will allow rendering a large animation by trading off memory for CPU consumption instead.

Typically instead of this rendering loop:
```cpp
   buffer = new uint8[stride * h]; // Huge
   for (i = 0; i < totalFrame; i++) {
        lottie_animation_render(animation, i, buffer, w, h, stride);
   }
   sendBufferToDisplay(buffer);
```
This allows this kind of loop:
```cpp
   const int lineCount = 10;
   buffer = new uint8[stride * lineCount]; // Small
   for (i = 0; i < totalFrame; i++) {
       for (l = 0; l < h; l += lineCount) {
          lottie_animation_render_partial(animation, i, buffer, w, h, l, l+lineCount, stride);
          sendBufferToDisplay(buffer, l);
      }
   }
```

The overhead is higher than a single rendering (mainly, clearing the buffer and computing the clip path n times) but allow to have a lot smaller buffers so it's very useful for limited/embedded system with almost no RAM like ESP32 or STM32.