### PR TITLE
example: lottieviewer - fixed frame no

### DIFF
--- a/example/lottieview.cpp
+++ b/example/lottieview.cpp
@@ -109,7 +109,6 @@ void LottieView::seek(float pos)
 {
     if (!mRenderDelegate) return;
 
-
     mPos = mapProgress(pos);
 
     // check if the pos maps to the current frame


### PR DESCRIPTION
There is a problem (issue #527) with totalFrame() in rlottie.
As lottieviewer didn't showed the actual frame number, but calculated it from
progress, it camouflaged the problem. Now the actual frame number and the
total number of frames are displayed.