### PR TITLE
Fix one frame missing

### DIFF
--- a/src/lottie/lottieitem.cpp
+++ b/src/lottie/lottieitem.cpp
@@ -443,7 +443,7 @@ VMatrix renderer::Layer::matrix(int frameNo) const
 bool renderer::Layer::visible() const
 {
     return (frameNo() >= mLayerData->inFrame() &&
-            frameNo() < mLayerData->outFrame());
+            frameNo() <= mLayerData->outFrame());
 }
 
 void renderer::Layer::preprocess(const VRect &clip)

--- a/src/lottie/lottiemodel.h
+++ b/src/lottie/lottiemodel.h
@@ -539,8 +539,8 @@ public:
     {
         return long(frameAtPos(timeInSec / duration()));
     }
-    size_t totalFrame() const { return mEndFrame - mStartFrame; }
-    long   frameDuration() const { return mEndFrame - mStartFrame - 1; }
+    size_t totalFrame() const { return mEndFrame - mStartFrame + 1; }
+    long   frameDuration() const { return mEndFrame - mStartFrame; }
     float  frameRate() const { return mFrameRate; }
     size_t startFrame() const { return mStartFrame; }
     size_t endFrame() const { return mEndFrame; }

--- a/src/lottie/lottieparser.cpp
+++ b/src/lottie/lottieparser.cpp
@@ -665,9 +665,9 @@ void LottieParserImpl::parseComposition()
         } else if (0 == strcmp(key, "h")) {
             comp->mSize.setHeight(GetInt());
         } else if (0 == strcmp(key, "ip")) {
-            comp->mStartFrame = GetDouble();
+            comp->mStartFrame = std::lround(GetDouble());
         } else if (0 == strcmp(key, "op")) {
-            comp->mEndFrame = GetDouble();
+            comp->mEndFrame = std::lround(GetDouble());
         } else if (0 == strcmp(key, "fr")) {
             comp->mFrameRate = GetDouble();
         } else if (0 == strcmp(key, "assets")) {


### PR DESCRIPTION
As mStartFrame and mEndFrame was counted from 0 and totalFrame() was
calculated as a difference, there were always one frame missing and
the animation rescaled. This patch adds one to the total frames count.
As there is 0.01 subtracted (copied from android implementation, needed
for some resources where frame no is non-whole number), added +2, not +1.
It fixes the problem for all tested resources- requested and all in example/resource.

issue: #527