### PR TITLE
Fix null dereference and buffer overflow 

### DIFF
--- a/src/vector/stb/stb_image.h
+++ b/src/vector/stb/stb_image.h
@@ -1930,7 +1930,7 @@ stbi_inline static int stbi__jpeg_huff_decode(stbi__jpeg *j, stbi__huffman *h)
 }
 
 // bias[n] = (-1<<n) + 1
-static const int stbi__jbias[16] = {0,-1,-3,-7,-15,-31,-63,-127,-255,-511,-1023,-2047,-4095,-8191,-16383,-32767};
+static const int stbi__jbias[17] = {0,-1,-3,-7,-15,-31,-63,-127,-255,-511,-1023,-2047,-4095,-8191,-16383,-32767,-65535};
 
 // combined JPEG 'receive' and JPEG 'extend', since baseline
 // always extends everything it receives.
@@ -3771,6 +3771,10 @@ static void *stbi__jpeg_load(stbi__context *s, int *x, int *y, int *comp, int re
 {
    unsigned char* result;
    stbi__jpeg* j = (stbi__jpeg*) stbi__malloc(sizeof(stbi__jpeg));
+   if (!j) {
+      stbi__errpuc("outofmem", "Out of memory");
+      return nullptr;
+   }
    STBI_NOTUSED(ri);
    j->s = s;
    stbi__setup_jpeg(j);
@@ -3783,6 +3787,10 @@ static int stbi__jpeg_test(stbi__context *s)
 {
    int r;
    stbi__jpeg* j = (stbi__jpeg*)stbi__malloc(sizeof(stbi__jpeg));
+   if (!j) {
+      stbi__errpuc("outofmem", "Out of memory");
+      return 0;
+   }
    j->s = s;
    stbi__setup_jpeg(j);
    r = stbi__decode_jpeg_header(j, STBI__SCAN_type);


### PR DESCRIPTION
Added null checks for stbi__jpeg pointers in stbi__jpeg_load and stbi__jpeg_test functions.

Added 17th element to stbi__jbias array in function stbi__extend_recive parameter n could be 16 causing a buffer overflow on return k + (stbi__jbias[n] & sgn)