### PR TITLE
Update color blending style in LottieItem

### DIFF
--- a/src/lottie/lottieitem.h
+++ b/src/lottie/lottieitem.h
@@ -106,9 +106,31 @@ public:
     }
 
     void release_surface(VBitmap &surface) { mCache.push_back(surface); }
+    bool is_layer_surface_created() const { return mIsLayerBitmapCreated; }
+    void create_layer_surface(size_t width, size_t height, VBitmap::Format format)
+    {
+        if (mIsLayerBitmapCreated) return;
+
+        mLayerBitmap = std::make_unique<VBitmap>(width, height, format);
+        mBitmapPainter = std::make_unique<VPainter>(mLayerBitmap.get());
+        mIsLayerBitmapCreated = true;
+    }
+    void delete_layer_surface()
+    {
+        if (!mIsLayerBitmapCreated) return;
+
+        mLayerBitmap.reset();
+        mBitmapPainter.reset();
+        mIsLayerBitmapCreated = false;
+    }
+    VPainter* get_layer_painter() const { return mBitmapPainter.get(); }
+    VBitmap* get_layer_surface() const { return mLayerBitmap.get(); }
 
 private:
     std::vector<VBitmap> mCache;
+    std::unique_ptr<VBitmap>   mLayerBitmap{nullptr};
+    std::unique_ptr<VPainter>  mBitmapPainter{nullptr};
+    bool                       mIsLayerBitmapCreated{false};
 };
 
 class Drawable final : public VDrawable {


### PR DESCRIPTION
This commit modifies the LottieItem rendering process to match Adobe After Effects blending style. Initially, the entire content of the layer is rendered to an intermediate buffer. Then, the buffer is rendered with applied alpha layer.

Current blending style:
![out0](https://user-images.githubusercontent.com/4451022/230362836-3ee9dc66-4e16-4bfb-8758-f15289fe8d82.png)

New Blending style: 
![out1](https://user-images.githubusercontent.com/4451022/230362890-5a676c84-5d4d-4b53-af5b-f3cb15c146f4.png)
