### PR TITLE
build: set `LIB_INSTALL_DIR` according to `PREFIX`

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -130,10 +130,6 @@ if (LOTTIE_ASAN)
     target_link_options(rlottie PUBLIC  -fsanitize=address)
 endif()
 
-if (NOT LIB_INSTALL_DIR)
-    set (LIB_INSTALL_DIR "/usr/lib")
-endif (NOT LIB_INSTALL_DIR)
-
 #declare source and include files
 add_subdirectory(inc)
 add_subdirectory(src)
@@ -146,6 +142,9 @@ endif()
 
 SET(PREFIX ${CMAKE_INSTALL_PREFIX})
 SET(EXEC_DIR ${PREFIX})
+if (NOT LIB_INSTALL_DIR)
+    set (LIB_INSTALL_DIR "${PREFIX}/lib")
+endif (NOT LIB_INSTALL_DIR)
 SET(LIBDIR ${LIB_INSTALL_DIR})
 SET(INCDIR ${PREFIX}/include)
 


### PR DESCRIPTION
This PR make `CMAKE_INSTALL_PREFIX` environment variable working as expected instead of installing `/lib` to hard-coded `/usr/lib`.