### PR TITLE
Fixed animation last key frame end time

### DIFF
--- a/src/lottie/lottieparser.cpp
+++ b/src/lottie/lottieparser.cpp
@@ -2032,6 +2032,7 @@ void LottieParserImpl::parseKeyFrame(model::KeyFrames<T, Tag> &obj)
             outTangent = parseInperpolatorPoint();
         } else if (0 == strcmp(key, "t")) {
             keyframe.start_ = GetDouble();
+            keyframe.end_ = keyframe.start_;
         } else if (0 == strcmp(key, "s")) {
             parsed.value = true;
             getValue(keyframe.value_.start_);


### PR DESCRIPTION
Init keyframe end time with its start time, will be updated when parsing next key frame if any (solves issue interpolating to last keyframe) - Solves issue 548 https://github.com/Samsung/rlottie/issues/548