### PR TITLE
Do not skip update when it has dynamic property

### DIFF
--- a/src/lottie/lottieitem.cpp
+++ b/src/lottie/lottieitem.cpp
@@ -109,6 +109,7 @@ renderer::Composition::Composition(std::shared_ptr<model::Composition> model)
 void renderer::Composition::setValue(const std::string &keypath,
                                      LOTVariant &       value)
 {
+    mHasDynamicValue = true;
     LOTKeyPath key(keypath);
     mRootLayer->resolveKeyPath(key, 0, value);
 }
@@ -117,7 +118,7 @@ bool renderer::Composition::update(int frameNo, const VSize &size,
                                    bool keepAspectRatio)
 {
     // check if cached frame is same as requested frame.
-    if ((mViewSize == size) && (mCurFrameNo == frameNo) &&
+    if (!mHasDynamicValue && (mViewSize == size) && (mCurFrameNo == frameNo) &&
         (mKeepAspectRatio == keepAspectRatio))
         return false;
 

--- a/src/lottie/lottieitem.h
+++ b/src/lottie/lottieitem.h
@@ -207,6 +207,7 @@ private:
     VArenaAlloc                         mAllocator{2048};
     int                                 mCurFrameNo;
     bool                                mKeepAspectRatio{true};
+    bool                                mHasDynamicValue{false};
 };
 
 class Layer {


### PR DESCRIPTION
In following cases,

```c++
animation->setValue<Property::FillColor>("**", red);
animation->render(0, surface);
// after render is finished
animation->setValue<Property::FillColor>("**", blue);
animation->render(0, surface);
```
Or
```c++
animation->setValue<Property::FillColor>("**", [&](const FrameInfo& info) {
    return colors->getColor();
});

colors->setColor(red);
animation->render(0, surface);
// after render is finished
colors->setColor(blue);
animation->render(0, surface);

```
the second render request for both cases should not be ignored even if it's the same request as previous.