### PR TITLE
tests: Fix frame counting

### DIFF
--- a/test/test_lottieanimation.cpp
+++ b/test/test_lottieanimation.cpp
@@ -26,7 +26,7 @@ TEST_F(AnimationTest, loadFromFile_N) {
 
 TEST_F(AnimationTest, loadFromFile) {
     ASSERT_TRUE(animation != nullptr);
-    ASSERT_EQ(animation->totalFrame(), 30);
+    ASSERT_EQ(animation->totalFrame(), 31);
     size_t width, height;
     animation->size(width, height);
     ASSERT_EQ(width, 500);

--- a/test/test_lottieanimation_capi.cpp
+++ b/test/test_lottieanimation_capi.cpp
@@ -26,7 +26,7 @@ TEST_F(AnimationCApiTest, loadFromFile_N) {
 
 TEST_F(AnimationCApiTest, loadFromFile) {
     ASSERT_TRUE(animation);
-    ASSERT_EQ(lottie_animation_get_totalframe(animation), 30);
+    ASSERT_EQ(lottie_animation_get_totalframe(animation), 31);
     size_t width, height;
     lottie_animation_get_size(animation, &width, &height);
     ASSERT_EQ(width, 500);


### PR DESCRIPTION
This change was introduced in 12facb81733fc9bc00c4a40704c32cc353b45e64
but didn't reflected in the unit tests.
