### PR TITLE
Fix use arm neon instructions if targeting 32-bit arm architectures only

### DIFF
--- a/src/lottie/lottieanimation.cpp
+++ b/src/lottie/lottieanimation.cpp
@@ -483,7 +483,7 @@ void lottie_shutdown_impl()
 #ifdef LOTTIE_LOGGING_SUPPORT
 void initLogging()
 {
-#if defined(__ARM_NEON__)
+#if defined(__ARM_NEON__) && defined(__arm__)
     set_log_level(LogLevel::OFF);
 #else
     initialize(GuaranteedLogger(), "/tmp/", "rlottie", 1);

--- a/src/lottie/lottieanimation.cpp
+++ b/src/lottie/lottieanimation.cpp
@@ -483,7 +483,7 @@ void lottie_shutdown_impl()
 #ifdef LOTTIE_LOGGING_SUPPORT
 void initLogging()
 {
-#if defined(__ARM_NEON__) && defined(__arm__)
+#if defined(__ARM_NEON__) && defined(__arm__) && !defined(__clang__)
     set_log_level(LogLevel::OFF);
 #else
     initialize(GuaranteedLogger(), "/tmp/", "rlottie", 1);

--- a/src/vector/vdrawhelper.cpp
+++ b/src/vector/vdrawhelper.cpp
@@ -754,7 +754,7 @@ void VSpanData::updateSpanFunc()
     }
 }
 
-#if !defined(__SSE2__) && !(defined(__ARM_NEON__) && defined(__arm__))
+#if !defined(__SSE2__) && !(defined(__ARM_NEON__) && defined(__arm__) && !defined(__clang__))
 void memfill32(uint32_t *dest, uint32_t value, int length)
 {
     // let compiler do the auto vectorization.

--- a/src/vector/vdrawhelper.cpp
+++ b/src/vector/vdrawhelper.cpp
@@ -754,7 +754,7 @@ void VSpanData::updateSpanFunc()
     }
 }
 
-#if !defined(__SSE2__) && !defined(__ARM_NEON__)
+#if !defined(__SSE2__) && !(defined(__ARM_NEON__) && defined(__arm__))
 void memfill32(uint32_t *dest, uint32_t value, int length)
 {
     // let compiler do the auto vectorization.

--- a/src/vector/vdrawhelper_common.cpp
+++ b/src/vector/vdrawhelper_common.cpp
@@ -180,7 +180,7 @@ RenderFuncTable::RenderFuncTable()
     updateSrc(BlendMode::DestIn, src_DestinationIn);
     updateSrc(BlendMode::DestOut, src_DestinationOut);
 
-#if defined(__ARM_NEON__)
+#if defined(__ARM_NEON__) && defined(__arm__)
     neon();
 #endif
 #if defined(__SSE2__)

--- a/src/vector/vdrawhelper_common.cpp
+++ b/src/vector/vdrawhelper_common.cpp
@@ -180,7 +180,7 @@ RenderFuncTable::RenderFuncTable()
     updateSrc(BlendMode::DestIn, src_DestinationIn);
     updateSrc(BlendMode::DestOut, src_DestinationOut);
 
-#if defined(__ARM_NEON__) && defined(__arm__)
+#if defined(__ARM_NEON__) && defined(__arm__) && !defined(__clang__)
     neon();
 #endif
 #if defined(__SSE2__)

--- a/src/vector/vdrawhelper_neon.cpp
+++ b/src/vector/vdrawhelper_neon.cpp
@@ -1,4 +1,4 @@
-#if defined(__ARM_NEON__)
+#if defined(__ARM_NEON__) && defined(__arm__)
 
 #include "vdrawhelper.h"
 

--- a/src/vector/vdrawhelper_neon.cpp
+++ b/src/vector/vdrawhelper_neon.cpp
@@ -1,4 +1,4 @@
-#if defined(__ARM_NEON__) && defined(__arm__)
+#if defined(__ARM_NEON__) && defined(__arm__) && !defined(__clang__)
 
 #include "vdrawhelper.h"
 


### PR DESCRIPTION
This fixes compilation for arm64 platforms that support neon instructions, like Apple Silicon, because the assembly code contained in `pixman-arm-neon-asm.S` is armv7 assembly, which is not supported by arm64 compilers.

Fixes #496.