### PR TITLE
Fix Stroke opacity not applied due to incomplete undo of 8cb666211b

### DIFF
--- a/src/lottie/lottieitem.cpp
+++ b/src/lottie/lottieitem.cpp
@@ -1306,9 +1306,9 @@ renderer::Stroke::Stroke(model::Stroke *data)
 static vthread_local std::vector<float> Dash_Vector;
 
 bool renderer::Stroke::updateContent(int frameNo, const VMatrix &matrix,
-                                     float)
+                                     float alfa)
 {
-    auto combinedAlpha = mModel.opacity(frameNo);
+    auto combinedAlpha = alfa * mModel.opacity(frameNo);
     auto color = mModel.color(frameNo).toColor(combinedAlpha);
 
     VBrush brush(color);


### PR DESCRIPTION
Completes "Revert "Update color blending style in LottieItem""

This reverts the missing part of commit 8cb666211b859267ec530ff8798c08c29aefecaf reverted in f969abf62c8df773e3951a1176000e70fcde637f.