### PR TITLE
Fix missing include

### DIFF
--- a/inc/rlottie.h
+++ b/inc/rlottie.h
@@ -23,6 +23,7 @@
 #ifndef _RLOTTIE_H_
 #define _RLOTTIE_H_
 
+#include <functional>
 #include <future>
 #include <vector>
 #include <memory>


### PR DESCRIPTION
There is usage of std::function, but there is no according header