### PR TITLE
Fix Windows Build

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -83,9 +83,14 @@ endif()
 set( CMAKE_THREAD_PREFER_PTHREAD TRUE )
 find_package( Threads )
 
+if(WIN32)
+   set( OSSPEC_LIBS Shlwapi.lib )
+endif()
+
 target_link_libraries(rlottie
                     PUBLIC
                         "${CMAKE_THREAD_LIBS_INIT}"
+                        ${OSSPEC_LIBS}
                      )
 
 if (NOT APPLE AND NOT WIN32)

--- a/src/lottie/lottieparser.cpp
+++ b/src/lottie/lottieparser.cpp
@@ -68,7 +68,6 @@ RAPIDJSON_DIAG_OFF(effc++)
 #include <windows.h>
 #include <shlwapi.h>
 
-#include <string_view>
 #endif
 
 #ifndef PATH_MAX
@@ -811,7 +810,7 @@ static std::string convertFromBase64(const std::string &str)
 namespace
 {
    #ifdef _WIN32
-   std::wstring ToStdWString( std::string_view str )
+   std::wstring ToStdWString( const std::string& str )
    {
       std::wstring wstr;
       int          nchars = ::MultiByteToWideChar(CP_UTF8, 0, str.data(), (int)str.length(), 0, 0);
@@ -826,7 +825,7 @@ namespace
       return wstr;
    }
 
-   std::string ToStdString( std::wstring_view wstr )
+   std::string ToStdString( const std::wstring& wstr )
    {
        std::string str;
        int         nchars = ::WideCharToMultiByte( CP_UTF8, 0, wstr.data(), (int)wstr.length(), NULL, NULL, NULL, NULL );
@@ -847,7 +846,7 @@ namespace
        std::wstring wpath = ToStdWString( path );
        std::wstring wresolved_path;
        wresolved_path.resize( PATH_MAX );
-       if ( PathCanonicalizeW( wresolved_path.data(), wpath.c_str() ) )
+       if ( PathCanonicalizeW( const_cast<wchar_t *>(wresolved_path.data()), wpath.c_str() ) )
        {
            std::string path = ToStdString(wresolved_path);
            strcpy_s( resolved_path, path.length() * sizeof( char ), path.c_str() );


### PR DESCRIPTION
Card: https://github.com/Samsung/rlottie/issues/576

Hello, thank you very much for the recent vulnerability patch! While doing updates we noticed that rlottie does not currently build on windows with the changes.

A recent commit: https://github.com/Samsung/rlottie/commit/346c9b604b4227b491f38e1c5a4dd43d4f7c45ac from mid-June uses PATH_MAX which isn't defined on Windows.

Additionally, `realpath` is a POSIX function: https://man7.org/linux/man-pages/man3/realpath.3.html so an equivalent is needed for Windows.

This PR resolves those two issues.
