### PR TITLE
Fix stack overflow vulnerability in gray_render_cubic

### DIFF
--- a/src/vector/freetype/v_ft_raster.cpp
+++ b/src/vector/freetype/v_ft_raster.cpp
@@ -806,6 +806,8 @@ gray_render_cubic(RAS_ARG_ const SW_FT_Vector* control1,
       continue;
 
     Split:
+      if ( arc - ras.bez_stack >= 31 * 3 )
+        return; // bez_stack size is 32*3+1
       gray_split_cubic( arc );
       arc += 3;
     }


### PR DESCRIPTION
Add a bounds check before gray_split_cubic(). Function uses bez_stack[32*3+1] as an arc stack, advancing arc by 3 on each split. When arc reaches offset (93), the write to arc[6] at index 99 exceeds the array boundary (max index 96)

A malicious Lottie file with wrong cubic curve could trigger this overflow.