### PR TITLE
Fix integer overflow in Gradient::populate()

### DIFF
--- a/src/lottie/lottiemodel.cpp
+++ b/src/lottie/lottiemodel.cpp
@@ -250,11 +250,14 @@ void model::Gradient::populate(VGradientStops &stops, int frameNo)
     auto                  size = gradData.mGradient.size();
     float *               ptr = gradData.mGradient.data();
     int                   colorPoints = mColorPoints;
-    size_t                colorPointsSize = colorPoints * 4;
     if (!ptr) return;
-    if (colorPoints < 0 || colorPointsSize > size) {  // for legacy bodymovin (ref: lottie-android)
+    if (colorPoints > 0 && (size_t)colorPoints > size / 4) {
         colorPoints = int(size / 4);
     }
+    if (colorPoints < 0) {  // for legacy bodymovin (ref: lottie-android)
+        colorPoints = int(size / 4);
+    }
+    size_t                colorPointsSize = (size_t)colorPoints * 4;
     auto   opacityArraySize = size - colorPointsSize;
     if (opacityArraySize % 2 != 0) {
         opacityArraySize = 0;


### PR DESCRIPTION
A signed integer overflow vulnerability existed in `src/lottie/lottiemodel.cpp` where the `colorPoints` value from untrusted JSON input (`g.p` field) could be set to values >= 0x40000000, causing `colorPoints * 4` to overflow to 0. This bypassed the bounds check and led to a heap buffer over-read during gradient rendering.