### PR TITLE
Fix crash vulnerabilities in path animation and layer parent handling

### DIFF
--- a/src/lottie/lottieitem.cpp
+++ b/src/lottie/lottieitem.cpp
@@ -447,8 +447,16 @@ void renderer::Layer::update(int frameNumber, const VMatrix &parentMatrix,
 
 VMatrix renderer::Layer::matrix(int frameNo) const
 {
+    return matrix(frameNo, 0);
+}
+
+VMatrix renderer::Layer::matrix(int frameNo, int depth) const
+{
+    // Prevent infinite recursion from cyclic parent references
+    if (depth > 64) return VMatrix{};
+
     return mParentLayer
-               ? (mLayerData->matrix(frameNo) * mParentLayer->matrix(frameNo))
+               ? (mLayerData->matrix(frameNo) * mParentLayer->matrix(frameNo, depth + 1))
                : mLayerData->matrix(frameNo);
 }
 

--- a/src/lottie/lottieitem.h
+++ b/src/lottie/lottieitem.h
@@ -223,6 +223,7 @@ public:
     virtual void update(int frameNo, const VMatrix &parentMatrix,
                         float parentAlpha);
     VMatrix      matrix(int frameNo) const;
+    VMatrix      matrix(int frameNo, int depth) const;
     void         preprocess(const VRect &clip);
     virtual DrawableList renderList() { return {}; }
     virtual void         render(VPainter *painter, const VRle &mask,

--- a/src/lottie/lottiemodel.h
+++ b/src/lottie/lottiemodel.h
@@ -345,6 +345,7 @@ public:
             value().toPath(path);
         } else {
             const auto &vec = animation().frames_;
+            if (vec.empty()) return;
             if (vec.front().start_ >= frameNo)
                 return vec.front().value_.start_.toPath(path);
             if (vec.back().end_ <= frameNo)


### PR DESCRIPTION
Two stability issues have been addressed:

1. PathData specialization: Added missing empty-frames guard in the Property<PathData>::value() method at lottiemodel.h. This prevents a null pointer dereference when animation keyframes are discarded during parsing, leaving the frames array empty.

2. Layer parent recursion: Added depth limiting to Layer::matrix() at lottieitem.cpp to prevent stack overflow from cyclic parent layer references. The method now uses an internal overload with a depth counter that returns an identity matrix when exceeding 64 levels.

Files changed:
  - src/lottie/lottiemodel.h: Added empty check before accessing frames
  - src/lottie/lottieitem.h: Declared overloaded matrix() with depth param
  - src/lottie/lottieitem.cpp: Implemented depth-limited matrix traversal