### PR TITLE
Fix heap buffer overflow from short truncation of span Y coordinate

### DIFF
--- a/src/vector/freetype/v_ft_raster.cpp
+++ b/src/vector/freetype/v_ft_raster.cpp
@@ -883,8 +883,8 @@ static void gray_hline(RAS_ARG_ TCoord x, TCoord y, TPos area, TCoord acount)
     /* SW_FT_Span.x is a 16-bit short, so limit our coordinates appropriately */
     if (x >= 32767) x = 32767;
 
-    /* SW_FT_Span.y is an integer, so limit our coordinates appropriately */
-    if (y >= SW_FT_INT_MAX) y = SW_FT_INT_MAX;
+    /* SW_FT_Span.y is a 16-bit short, so limit our coordinates appropriately */
+    if (y >= 32767) y = 32767;
 
     if (coverage) {
         SW_FT_Span* span;


### PR DESCRIPTION
SW_FT_Span.y is a 16-bit short, so limit our coordinates appropriately.

The clamp (and its "is an integer" comment) was inherited from upstream FreeType's ftgrays.c, where FT_Span has no y field and the scanline y is carried separately as an int. Rlottie added a `short y` to the span struct without adapting the clamp, so the INT_MAX bound never prevented the (short) narrowing at the store site.