### PR TITLE
Safety limits to precomp, repeater, and polystar handling

### DIFF
--- a/src/lottie/lottieitem.cpp
+++ b/src/lottie/lottieitem.cpp
@@ -83,12 +83,27 @@ static bool trimProp(rlottie::Property prop)
     }
 }
 
+static constexpr int    kMaxLayerDepth = 32;      // precomp nesting-depth limit
+static constexpr size_t kMaxLayerNodes = 100000;  // global render-node budget
+
 static renderer::Layer *createLayerItem(model::Layer *layerData,
-                                        VArenaAlloc * allocator)
+                                        VArenaAlloc *allocator, int depth,
+                                        size_t &nodeBudget)
 {
+    if (depth >= kMaxLayerDepth) {
+        vWarning << "Max precomp nesting depth (" << kMaxLayerDepth << ") exceeded";
+        return nullptr;
+    }
+    if (nodeBudget == 0) {
+        vWarning << "Max render node budget (" << kMaxLayerNodes << ") exceeded";
+        return nullptr;
+    }
+    --nodeBudget;
+
     switch (layerData->mLayerType) {
     case model::Layer::Type::Precomp: {
-        return allocator->make<renderer::CompLayer>(layerData, allocator);
+        return allocator->make<renderer::CompLayer>(layerData, allocator,
+                                                    depth + 1, nodeBudget);
     }
     case model::Layer::Type::Solid: {
         return allocator->make<renderer::SolidLayer>(layerData);
@@ -112,7 +127,8 @@ renderer::Composition::Composition(std::shared_ptr<model::Composition> model)
     : mCurFrameNo(-1)
 {
     mModel = std::move(model);
-    mRootLayer = createLayerItem(mModel->mRootLayer, &mAllocator);
+    size_t nodeBudget = kMaxLayerNodes;
+    mRootLayer = createLayerItem(mModel->mRootLayer, &mAllocator, 0, nodeBudget);
     mRootLayer->setComplexContent(false);
     mViewSize = mModel->size();
 }
@@ -477,7 +493,8 @@ void renderer::Layer::preprocess(const VRect &clip)
     preprocessStage(clip);
 }
 
-renderer::CompLayer::CompLayer(model::Layer *layerModel, VArenaAlloc *allocator)
+renderer::CompLayer::CompLayer(model::Layer *layerModel, VArenaAlloc *allocator,
+                               int depth, size_t &nodeBudget)
     : renderer::Layer(layerModel)
 {
     if (!mLayerData->mChildren.empty())
@@ -489,7 +506,7 @@ renderer::CompLayer::CompLayer(model::Layer *layerModel, VArenaAlloc *allocator)
          it != mLayerData->mChildren.rend(); ++it) {
         if ((*it)->type() != model::Object::Type::Layer) continue;
         auto model = static_cast<model::Layer *>(*it);
-        auto item = createLayerItem(model, allocator);
+        auto item = createLayerItem(model, allocator, depth, nodeBudget);
         if (item) mLayers.push_back(item);
     }
 
@@ -541,6 +558,17 @@ void renderer::CompLayer::renderHelper(VPainter *    painter,
                                        const VRle &  matteRle,
                                        SurfaceCache &cache)
 {
+    if (cache.mRenderDepth >= kMaxLayerDepth) {
+        vWarning << "Max precomp render depth (" << kMaxLayerDepth << ") exceeded";
+        return;
+    }
+    ++cache.mRenderDepth;
+    // Decrement on every exit path (including the early returns below).
+    struct DepthGuard {
+        SurfaceCache &c;
+        ~DepthGuard() { --c.mRenderDepth; }
+    } depthGuard{cache};
+
     VRle mask;
     if (mLayerMask) {
         mask = mLayerMask->maskRle(painter->clipBoundingRect());

--- a/src/lottie/lottieitem.h
+++ b/src/lottie/lottieitem.h
@@ -107,6 +107,8 @@ public:
 
     void release_surface(VBitmap &surface) { mCache.push_back(surface); }
 
+    int mRenderDepth{0};
+
 private:
     std::vector<VBitmap> mCache;
 };
@@ -272,7 +274,8 @@ protected:
 
 class CompLayer final : public Layer {
 public:
-    explicit CompLayer(model::Layer *layerData, VArenaAlloc *allocator);
+    CompLayer(model::Layer *layerData, VArenaAlloc *allocator, int depth,
+              size_t &nodeBudget);
 
     void render(VPainter *painter, const VRle &mask, const VRle &matteRle,
                 SurfaceCache &cache) final;

--- a/src/lottie/lottiemodel.cpp
+++ b/src/lottie/lottiemodel.cpp
@@ -29,6 +29,13 @@
 
 using namespace rlottie::internal;
 
+static constexpr int kMaxModelTreeDepth = 32;
+struct DepthGuard {
+    int &mDepth;
+    explicit DepthGuard(int &depth) : mDepth(depth) { ++mDepth; }
+    ~DepthGuard() { --mDepth; }
+};
+
 /*
  * We process the iterator objects in the children list
  * by iterating from back to front. when we find a repeater object
@@ -82,6 +89,11 @@ public:
         switch (obj->type()) {
         case model::Object::Type::Group:
         case model::Object::Type::Layer: {
+            if (mDepth >= kMaxModelTreeDepth) {
+                vWarning << "Max precomp nesting depth (" << kMaxModelTreeDepth << ") exceeded";
+                break;
+            }
+            DepthGuard guard(mDepth);
             visitChildren(static_cast<model::Group *>(obj));
             break;
         }
@@ -89,6 +101,9 @@ public:
             break;
         }
     }
+
+private:
+    int mDepth{0};
 };
 
 class LottieUpdateStatVisitor {
@@ -127,6 +142,8 @@ public:
     }
     void visit(model::Object *obj)
     {
+        if (mDepth >= kMaxModelTreeDepth) return;
+        DepthGuard guard(mDepth);
         switch (obj->type()) {
         case model::Object::Type::Layer: {
             visitLayer(static_cast<model::Layer *>(obj));
@@ -144,6 +161,9 @@ public:
             break;
         }
     }
+
+private:
+    int mDepth{0};
 };
 
 void model::Composition::processRepeaterObjects()

--- a/src/lottie/lottiemodel.h
+++ b/src/lottie/lottiemodel.h
@@ -990,7 +990,13 @@ public:
     Repeater() : Object(Object::Type::Repeater) {}
     Group *content() const { return mContent ? mContent : nullptr; }
     void   setContent(Group *content) { mContent = content; }
-    int    maxCopies() const { return int(mMaxCopies); }
+    static constexpr float kMaxRepeaterCopies = 10000.0f;
+    int    maxCopies() const
+    {
+        if (!std::isfinite(mMaxCopies) || mMaxCopies <= 0.0f) return 0;
+        if (mMaxCopies > kMaxRepeaterCopies) return int(kMaxRepeaterCopies);
+        return int(mMaxCopies);
+    }
     float  copies(int frameNo) const { return mCopies.value(frameNo); }
     float  offset(int frameNo) const { return mOffset.value(frameNo); }
     bool   processed() const { return mProcessed; }

--- a/src/vector/vpath.cpp
+++ b/src/vector/vpath.cpp
@@ -21,6 +21,7 @@
  */
 #include "vpath.h"
 #include <cassert>
+#include <cmath>
 #include <iterator>
 #include <vector>
 #include "vbezier.h"
@@ -518,6 +519,7 @@ void VPath::VPathData::addPolystar(float points, float innerRadius,
                                    float cx, float cy, VPath::Direction dir)
 {
     constexpr float    MAX_POLY_POINTS = 1024.0f;
+    if (!std::isfinite(points) || points < 1.0f) return;
     if (points > MAX_POLY_POINTS) points = MAX_POLY_POINTS;
     const static float POLYSTAR_MAGIC_NUMBER = 0.47829f / 0.28f;
     float              currentAngle = (startAngle - 90.0f) * K_PI / 180.0f;
@@ -625,6 +627,7 @@ void VPath::VPathData::addPolygon(float points, float radius, float roundness,
 {
     // TODO: Need to support floating point number for number of points
     constexpr float    MAX_POLY_POINTS = 1024.0f;
+    if (!std::isfinite(points) || points < 1.0f) return;
     if (points > MAX_POLY_POINTS) points = MAX_POLY_POINTS;
     const static float POLYGON_MAGIC_NUMBER = 0.25;
     float              currentAngle = (startAngle - 90.0f) * K_PI / 180.0f;


### PR DESCRIPTION
Introduce bounds to keep resource use predictable on deeply nested or oversized inputs:
- Cap precomp nesting depth in repeater processing, render-tree build, and render walk
- Cap total render-node count for wide precomp graphs
- Clamp repeater copy count to a sane maximum
- Validate polystar point count (reject non-finite/negative)