### PR TITLE
Fix layer rotation ignored when "ddd" key is omitted (issue #581)

### DIFF
--- a/src/lottie/lottieparser.cpp
+++ b/src/lottie/lottieparser.cpp
@@ -1121,7 +1121,7 @@ model::Layer *LottieParserImpl::parseLayer()
 {
     model::Layer *layer = allocator().make<model::Layer>();
     curLayerRef = layer;
-    bool ddd = true;
+    bool ddd = false;
     EnterObject();
     while (const char *key = NextObjectKey()) {
         if (0 == strcmp(key, "ty")) { /* Type of layer*/

--- a/test/test_lottieanimation.cpp
+++ b/test/test_lottieanimation.cpp
@@ -1,5 +1,6 @@
 #include <gtest/gtest.h>
 #include "rlottie.h"
+#include <vector>
 
 class AnimationTest : public ::testing::Test {
 public:
@@ -22,6 +23,35 @@ public:
 
 TEST_F(AnimationTest, loadFromFile_N) {
     ASSERT_FALSE(animationInvalid);
+}
+
+// Regression test for https://github.com/Samsung/rlottie/issues/581:
+// a layer that omits the "ddd" key must be treated as 2D so that
+// layer-level rotation keyframes (ks.r) are applied.
+TEST(AnimationRotation, layerWithoutDddRotates) {
+    static const char *json =
+        "{\"v\":\"5.7.1\",\"fr\":30,\"ip\":0,\"op\":60,\"w\":120,\"h\":120,\"nm\":\"RotTest\","
+        "\"layers\":[{\"ty\":4,\"nm\":\"Bar\",\"ind\":0,\"ip\":0,\"op\":60,\"st\":0,\"ks\":{"
+        "\"o\":{\"a\":0,\"k\":100},"
+        "\"r\":{\"a\":1,\"k\":[{\"t\":0,\"s\":[0],\"e\":[360],\"i\":{\"x\":[1],\"y\":[1]},\"o\":{\"x\":[0],\"y\":[0]}},{\"t\":59,\"s\":[360]}]},"
+        "\"p\":{\"a\":0,\"k\":[60,60,0]},\"a\":{\"a\":0,\"k\":[0,0,0]},\"s\":{\"a\":0,\"k\":[100,100,100]}},"
+        "\"shapes\":[{\"ty\":\"gr\",\"nm\":\"G\",\"it\":["
+        "{\"ty\":\"rc\",\"p\":{\"a\":0,\"k\":[0,-30]},\"s\":{\"a\":0,\"k\":[6,40]},\"r\":{\"a\":0,\"k\":0}},"
+        "{\"ty\":\"fl\",\"nm\":\"Fill 1\",\"c\":{\"a\":0,\"k\":[1,1,1,1]},\"o\":{\"a\":0,\"k\":100}},"
+        "{\"ty\":\"tr\",\"p\":{\"a\":0,\"k\":[0,0]},\"a\":{\"a\":0,\"k\":[0,0]},\"s\":{\"a\":0,\"k\":[100,100]},\"r\":{\"a\":0,\"k\":0},\"o\":{\"a\":0,\"k\":100}}"
+        "]}]}]}";
+    auto animation = rlottie::Animation::loadFromData(json, "issue581");
+    ASSERT_TRUE(animation != nullptr);
+
+    const size_t w = 120, h = 120;
+    std::vector<uint32_t> frame0(w * h, 0), frameMid(w * h, 0);
+    rlottie::Surface s0(frame0.data(), w, h, w * 4);
+    animation->renderSync(0, s0);
+    rlottie::Surface sMid(frameMid.data(), w, h, w * 4);
+    animation->renderSync(15, sMid);
+
+    // a 360 degree rotation must change the rendered pixels between frames
+    ASSERT_TRUE(frame0 != frameMid);
 }
 
 TEST_F(AnimationTest, loadFromFile) {


### PR DESCRIPTION
Fixes #581

## Problem

`parseLayer()` in `src/lottie/lottieparser.cpp` initialized the 3D flag with `bool ddd = true;`. Any layer that doesn't explicitly set `"ddd": 0` was therefore parsed as 3D. In 3D mode `Transform::Data::matrix()` takes rotation from `mExtra->m3DRz` — which has no keyframes — instead of `mRotation`, so **layer-level rotation keyframes (`ks.r`) render as static**. After Effects omits the `"ddd"` key for 2D layers, so this affects most real Lottie files (they animate correctly in lottie-web).

Per the [Lottie spec](https://lottiefiles.github.io/lottie-docs/), `"ddd"` defaults to `0` (2D) — which is also the default of this file's own `parseTransformObject(bool ddd = false)`. The `true` initializer contradicts that.

## Fix

One line: `bool ddd = true;` → `bool ddd = false;`, so a layer with no `"ddd"` key is treated as 2D and its rotation is applied.

## Verification

Built with `-DLOTTIE_TEST=ON` and rendered the reproduction from the issue (a bar with a 360° rotation) at frame 0 and frame 15:

- **before:** 0 pixels differ between the two frames (rotation ignored — bug reproduced)
- **after:** 526 pixels differ (rotation applied)

Added a gtest regression test (`AnimationRotation.layerWithoutDddRotates`) that asserts the two frames differ; it fails on `master` and passes with this change. The rest of the animation suite is unchanged by this commit (the two pre-existing `loadFromFile` failures on `master` are an unrelated `totalFrame()` 30-vs-31 expectation mismatch, present before this change).

🤖 Generated with [Claude Code](https://claude.com/claude-code)