### PR TITLE
Add shape-content budget to bound repeater cost

### DIFF
--- a/src/lottie/lottieitem.cpp
+++ b/src/lottie/lottieitem.cpp
@@ -86,9 +86,20 @@ static bool trimProp(rlottie::Property prop)
 static constexpr int    kMaxLayerDepth = 32;      // precomp nesting-depth limit
 static constexpr size_t kMaxLayerNodes = 100000;  // global render-node budget
 
+// Global weighted-cost budget shared across a whole composition's shape /
+// repeater content tree. Each constructed content node (group, paint,
+// repeater copy) charges at least 1 unit, and point-heavy shapes (polystar,
+// custom path) charge their actual point count. This bounds the
+// copies x points-per-shape amplification a repeater can produce, and also
+// bounds nested repeaters (repeater whose content contains another
+// repeater), since every copy at every nesting level draws from the same
+// shared budget.
+static constexpr size_t kMaxShapeContentBudget = 15000;
+
 static renderer::Layer *createLayerItem(model::Layer *layerData,
                                         VArenaAlloc *allocator, int depth,
-                                        size_t &nodeBudget)
+                                        size_t &nodeBudget,
+                                        size_t &contentBudget)
 {
     if (depth >= kMaxLayerDepth) {
         vWarning << "Max precomp nesting depth (" << kMaxLayerDepth << ") exceeded";
@@ -103,13 +114,15 @@ static renderer::Layer *createLayerItem(model::Layer *layerData,
     switch (layerData->mLayerType) {
     case model::Layer::Type::Precomp: {
         return allocator->make<renderer::CompLayer>(layerData, allocator,
-                                                    depth + 1, nodeBudget);
+                                                    depth + 1, nodeBudget,
+                                                    contentBudget);
     }
     case model::Layer::Type::Solid: {
         return allocator->make<renderer::SolidLayer>(layerData);
     }
     case model::Layer::Type::Shape: {
-        return allocator->make<renderer::ShapeLayer>(layerData, allocator);
+        return allocator->make<renderer::ShapeLayer>(layerData, allocator,
+                                                      contentBudget);
     }
     case model::Layer::Type::Null: {
         return allocator->make<renderer::NullLayer>(layerData);
@@ -128,7 +141,9 @@ renderer::Composition::Composition(std::shared_ptr<model::Composition> model)
 {
     mModel = std::move(model);
     size_t nodeBudget = kMaxLayerNodes;
-    mRootLayer = createLayerItem(mModel->mRootLayer, &mAllocator, 0, nodeBudget);
+    size_t contentBudget = kMaxShapeContentBudget;
+    mRootLayer = createLayerItem(mModel->mRootLayer, &mAllocator, 0, nodeBudget,
+                                 contentBudget);
     mRootLayer->setComplexContent(false);
     mViewSize = mModel->size();
 }
@@ -494,7 +509,8 @@ void renderer::Layer::preprocess(const VRect &clip)
 }
 
 renderer::CompLayer::CompLayer(model::Layer *layerModel, VArenaAlloc *allocator,
-                               int depth, size_t &nodeBudget)
+                               int depth, size_t &nodeBudget,
+                               size_t &contentBudget)
     : renderer::Layer(layerModel)
 {
     if (!mLayerData->mChildren.empty())
@@ -506,7 +522,8 @@ renderer::CompLayer::CompLayer(model::Layer *layerModel, VArenaAlloc *allocator,
          it != mLayerData->mChildren.rend(); ++it) {
         if ((*it)->type() != model::Object::Type::Layer) continue;
         auto model = static_cast<model::Layer *>(*it);
-        auto item = createLayerItem(model, allocator, depth, nodeBudget);
+        auto item = createLayerItem(model, allocator, depth, nodeBudget,
+                                    contentBudget);
         if (item) mLayers.push_back(item);
     }
 
@@ -813,13 +830,44 @@ renderer::NullLayer::NullLayer(model::Layer *layerData)
 }
 void renderer::NullLayer::updateContent() {}
 
+// Weighted cost of a single content item against kMaxShapeContentBudget.
+// Point-heavy shapes (polystar/polygon, custom path) charge their actual
+// point count (worst case MAX_POLY_POINTS for animated polystars, since the
+// per-frame value isn't known yet); everything else is a cheap wrapper/paint
+// node and charges a flat 1.
+static size_t contentItemCost(model::Object *contentData)
+{
+    constexpr float kMaxPolyPoints = 1024.0f;
+    switch (contentData->type()) {
+    case model::Object::Type::Polystar: {
+        auto *data = static_cast<model::Polystar *>(contentData);
+        float pts = data->mPointCount.isStatic() ? data->mPointCount.value(0)
+                                                 : kMaxPolyPoints;
+        if (!std::isfinite(pts)) pts = kMaxPolyPoints;
+        pts = std::min(std::max(pts, 1.0f), kMaxPolyPoints);
+        return size_t(pts);
+    }
+    case model::Object::Type::Path: {
+        auto *data = static_cast<model::Path *>(contentData);
+        if (data->mShape.isStatic()) {
+            return std::max<size_t>(1, data->mShape.value().mPoints.size());
+        }
+        return size_t(kMaxPolyPoints);
+    }
+    default:
+        return 1;
+    }
+}
+
 static renderer::Object *createContentItem(model::Object *contentData,
-                                           VArenaAlloc *  allocator)
+                                           VArenaAlloc *  allocator,
+                                           size_t &       contentBudget)
 {
     switch (contentData->type()) {
     case model::Object::Type::Group: {
         return allocator->make<renderer::Group>(
-            static_cast<model::Group *>(contentData), allocator);
+            static_cast<model::Group *>(contentData), allocator,
+            contentBudget);
     }
     case model::Object::Type::Rect: {
         return allocator->make<renderer::Rect>(
@@ -855,7 +903,8 @@ static renderer::Object *createContentItem(model::Object *contentData,
     }
     case model::Object::Type::Repeater: {
         return allocator->make<renderer::Repeater>(
-            static_cast<model::Repeater *>(contentData), allocator);
+            static_cast<model::Repeater *>(contentData), allocator,
+            contentBudget);
     }
     case model::Object::Type::Trim: {
         return allocator->make<renderer::Trim>(
@@ -868,11 +917,13 @@ static renderer::Object *createContentItem(model::Object *contentData,
 }
 
 renderer::ShapeLayer::ShapeLayer(model::Layer *layerData,
-                                 VArenaAlloc * allocator)
+                                 VArenaAlloc * allocator,
+                                 size_t &      contentBudget)
     : renderer::Layer(layerData),
-      mRoot(allocator->make<renderer::Group>(nullptr, allocator))
+      mRoot(allocator->make<renderer::Group>(nullptr, allocator,
+                                             contentBudget))
 {
-    mRoot->addChildren(layerData, allocator);
+    mRoot->addChildren(layerData, allocator, contentBudget);
 
     std::vector<renderer::Shape *> list;
     mRoot->processPaintItems(list);
@@ -988,13 +1039,15 @@ bool renderer::Stroke::resolveKeyPath(LOTKeyPath &keyPath, uint32_t depth,
     return false;
 }
 
-renderer::Group::Group(model::Group *data, VArenaAlloc *allocator)
+renderer::Group::Group(model::Group *data, VArenaAlloc *allocator,
+                       size_t &contentBudget)
     : mModel(data)
 {
-    addChildren(data, allocator);
+    addChildren(data, allocator, contentBudget);
 }
 
-void renderer::Group::addChildren(model::Group *data, VArenaAlloc *allocator)
+void renderer::Group::addChildren(model::Group *data, VArenaAlloc *allocator,
+                                  size_t &contentBudget)
 {
     if (!data) return;
 
@@ -1004,7 +1057,15 @@ void renderer::Group::addChildren(model::Group *data, VArenaAlloc *allocator)
     // as lottie model keeps it in front-to-back order.
     for (auto it = data->mChildren.crbegin(); it != data->mChildren.rend();
          ++it) {
-        auto content = createContentItem(*it, allocator);
+        size_t cost = contentItemCost(*it);
+        if (cost > contentBudget) {
+            vWarning << "Max shape content budget ("
+                     << kMaxShapeContentBudget << ") exceeded, dropping content item";
+            continue;
+        }
+        contentBudget -= cost;
+
+        auto content = createContentItem(*it, allocator, contentBudget);
         if (content) {
             mContents.push_back(content);
         }
@@ -1518,19 +1579,29 @@ void renderer::Trim::addPathItems(std::vector<renderer::Shape *> &list,
               back_inserter(mPathItems));
 }
 
-renderer::Repeater::Repeater(model::Repeater *data, VArenaAlloc *allocator)
+renderer::Repeater::Repeater(model::Repeater *data, VArenaAlloc *allocator,
+                             size_t &contentBudget)
     : mRepeaterData(data)
 {
     assert(mRepeaterData->content());
 
-    mCopies = mRepeaterData->maxCopies();
+    int maxCopies = mRepeaterData->maxCopies();
 
-    for (int i = 0; i < mCopies; i++) {
+
+    for (int i = 0; i < maxCopies; i++) {
+        if (contentBudget == 0) {
+            vWarning << "Max shape content budget (" << kMaxShapeContentBudget
+                     << ") exceeded, clamping repeater copies to " << i;
+            break;
+        }
+        --contentBudget;  // charge for this copy's own group wrapper
+
         auto content = allocator->make<renderer::Group>(
-            mRepeaterData->content(), allocator);
+            mRepeaterData->content(), allocator, contentBudget);
         // content->setParent(this);
         mContents.push_back(content);
     }
+    mCopies = int(mContents.size());
 }
 
 void renderer::Repeater::update(int frameNo, const VMatrix &parentMatrix,

--- a/src/lottie/lottieitem.h
+++ b/src/lottie/lottieitem.h
@@ -275,7 +275,7 @@ protected:
 class CompLayer final : public Layer {
 public:
     CompLayer(model::Layer *layerData, VArenaAlloc *allocator, int depth,
-              size_t &nodeBudget);
+              size_t &nodeBudget, size_t &contentBudget);
 
     void render(VPainter *painter, const VRle &mask, const VRle &matteRle,
                 SurfaceCache &cache) final;
@@ -319,7 +319,8 @@ class Group;
 
 class ShapeLayer final : public Layer {
 public:
-    explicit ShapeLayer(model::Layer *layerData, VArenaAlloc *allocator);
+    explicit ShapeLayer(model::Layer *layerData, VArenaAlloc *allocator,
+                        size_t &contentBudget);
     DrawableList renderList() final;
     void         buildLayerNode() final;
     bool         resolveKeyPath(LOTKeyPath &keyPath, uint32_t depth,
@@ -379,8 +380,10 @@ class Shape;
 class Group : public Object {
 public:
     Group() = default;
-    explicit Group(model::Group *data, VArenaAlloc *allocator);
-    void addChildren(model::Group *data, VArenaAlloc *allocator);
+    explicit Group(model::Group *data, VArenaAlloc *allocator,
+                   size_t &contentBudget);
+    void addChildren(model::Group *data, VArenaAlloc *allocator,
+                     size_t &contentBudget);
     void update(int frameNo, const VMatrix &parentMatrix, float parentAlpha,
                 const DirtyFlag &flag) override;
     void applyTrim();
@@ -618,7 +621,8 @@ private:
 
 class Repeater final : public Group {
 public:
-    explicit Repeater(model::Repeater *data, VArenaAlloc *allocator);
+    explicit Repeater(model::Repeater *data, VArenaAlloc *allocator,
+                      size_t &contentBudget);
     void update(int frameNo, const VMatrix &parentMatrix, float parentAlpha,
                 const DirtyFlag &flag) final;
     void renderList(std::vector<VDrawable *> &list) final;


### PR DESCRIPTION
Repeaters can multiply a shape by up to 10000 copies, and each shape can have up to 1024 points. Multiplying both together (or nesting repeaters inside each other) could still produce very large amounts of render work per frame, even though each setting on its own stayed within the existing limits.

Add a shared budget (15000 weighted points) that is spent while building the shape tree. Point-heavy shapes (stars, custom paths) spend more of the budget, simple shapes spend very little. Repeater copies and nested repeaters draw from the same shared budget, so copies stop being created once it runs out.

Patch keeps normal animations working as before, while capping the worst-case render cost for unusual or extreme content.